### PR TITLE
parseAsync will now use the global queue as the default queue and cor…

### DIFF
--- a/Sources/FeedKit/Parser/FeedParser.swift
+++ b/Sources/FeedKit/Parser/FeedParser.swift
@@ -100,23 +100,23 @@ public class FeedParser {
     
     /**
      
-     Starts parsing the feed asynchronously. Parsing runs by default on the main queue. 
-     So it is safe to run any UI code on the result closure.
-     
-     If a different queue is specified, the user is responsible to manually bring the 
-     resulting closure to whichever queue is apropriate. Usually `DispatchQueue.main.async`.
-     
-     If you're unsure, don't provide the `queue` parameter.
-     
-     - parameter queue: The queue on which the completion handler is dispatched.
-     - parameter result: The parse result
-     
-     */
-    public func parseAsync(queue: DispatchQueue = DispatchQueue.main, result: @escaping (Result) -> Void) {
-        queue.async {
-            result(self.parse())
-        }
-    }
+	Starts parsing the feed asynchronously. Parsing runs by default on the global queue.
+	So it is safe to run any UI code on the result closure.
+	
+	If you're unsure, don't provide the `queue` parameter.
+	
+	- parameter queue: The queue on which the completion handler is dispatched.
+	- parameter result: The parse result
+	
+	*/
+	public func parseAsync(queue: DispatchQueue = DispatchQueue.global(), result: @escaping (Result) -> Void) {
+		queue.async {
+			let parsedResult = self.parse()
+			DispatchQueue.main.async {
+				result(parsedResult)
+			}
+		}
+	}
     
     /**
      


### PR DESCRIPTION
Changes the method parseAsync to default to the global queue, but also bring back the result to the main thread.

The reason for this change, is that the method `parse()` is essentially the same as `parseAsync()` (when not providing any queue) because they both run on the main thread. The problem then is, that you can specify another queue to run this on, but even still, you have to parse the data asynchronously, then bring that data back to the main thread and continue. 
This is essentially the same as just using `parse()` in your own async closure and then bringing it back to the main thread, eliminating the need of `parseAsync().`

I think this is much more user friendly and intuitive, as the intention of parseAsync seems ambiguous.