### PR TITLE
Detect existing data encoding and convert to UTF-8 before parsing

### DIFF
--- a/FeedKit.xcodeproj/project.pbxproj
+++ b/FeedKit.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		83E6935A1FB3B3AE009A91C4 /* Data + toUtf8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E693591FB3B3AD009A91C4 /* Data + toUtf8.swift */; };
+		83E6935B1FB3B3B5009A91C4 /* Data + toUtf8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E693591FB3B3AD009A91C4 /* Data + toUtf8.swift */; };
+		83E6935C1FB3B3B5009A91C4 /* Data + toUtf8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E693591FB3B3AD009A91C4 /* Data + toUtf8.swift */; };
+		83E6935D1FB3B3B6009A91C4 /* Data + toUtf8.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83E693591FB3B3AD009A91C4 /* Data + toUtf8.swift */; };
 		A01F67A01D1692B20038910F /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01F679C1D16922D0038910F /* ViewController.swift */; };
 		A01F67A11D16931A0038910F /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = A01F67991D1691510038910F /* Main.storyboard */; };
 		A09AFB3A1EEFDFF40076ACC7 /* AtomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A09AFB2E1EEFDFF40076ACC7 /* AtomTests.swift */; };
@@ -558,6 +562,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		83E693591FB3B3AD009A91C4 /* Data + toUtf8.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Data + toUtf8.swift"; sourceTree = "<group>"; };
 		A01F679A1D1691510038910F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		A01F679C1D16922D0038910F /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		A0370EB91CEF9D5A009583A3 /* FeedKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FeedKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -912,6 +917,7 @@
 		A0F6B7C61F6E6E9600220625 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				83E693591FB3B3AD009A91C4 /* Data + toUtf8.swift */,
 				A0F6B7C71F6E6E9600220625 /* Array + Equatable.swift */,
 				A0F6B7C81F6E6E9600220625 /* String + toBool.swift */,
 				A0F6B7C91F6E6E9600220625 /* String + toDate.swift */,
@@ -1553,6 +1559,7 @@
 				A0F6B8561F6E6EB800220625 /* MediaCredit.swift in Sources */,
 				A0F6B8511F6E6EB800220625 /* iTunesSubCategory.swift in Sources */,
 				A0F6B8301F6E6EB800220625 /* Array + Equatable.swift in Sources */,
+				83E6935D1FB3B3B6009A91C4 /* Data + toUtf8.swift in Sources */,
 				A0F6B83E1F6E6EB800220625 /* AtomFeedEntryContributor.swift in Sources */,
 				A0F6B8591F6E6EB800220625 /* MediaGroup.swift in Sources */,
 				A0F6B85C1F6E6EB800220625 /* MediaLocation.swift in Sources */,
@@ -1742,6 +1749,7 @@
 				A0F6B90E1F6E6EBB00220625 /* MediaCredit.swift in Sources */,
 				A0F6B9091F6E6EBB00220625 /* iTunesSubCategory.swift in Sources */,
 				A0F6B8E81F6E6EBA00220625 /* Array + Equatable.swift in Sources */,
+				83E6935B1FB3B3B5009A91C4 /* Data + toUtf8.swift in Sources */,
 				A0F6B8F61F6E6EBB00220625 /* AtomFeedEntryContributor.swift in Sources */,
 				A0F6B9111F6E6EBB00220625 /* MediaGroup.swift in Sources */,
 				A0F6B9141F6E6EBB00220625 /* MediaLocation.swift in Sources */,
@@ -1841,6 +1849,7 @@
 				A0F6B8B21F6E6EBA00220625 /* MediaCredit.swift in Sources */,
 				A0F6B8AD1F6E6EBA00220625 /* iTunesSubCategory.swift in Sources */,
 				A0F6B88C1F6E6EBA00220625 /* Array + Equatable.swift in Sources */,
+				83E6935C1FB3B3B5009A91C4 /* Data + toUtf8.swift in Sources */,
 				A0F6B89A1F6E6EBA00220625 /* AtomFeedEntryContributor.swift in Sources */,
 				A0F6B8B51F6E6EBA00220625 /* MediaGroup.swift in Sources */,
 				A0F6B8B81F6E6EBA00220625 /* MediaLocation.swift in Sources */,
@@ -1940,6 +1949,7 @@
 				A0F6B96A1F6E6EBB00220625 /* MediaCredit.swift in Sources */,
 				A0F6B9651F6E6EBB00220625 /* iTunesSubCategory.swift in Sources */,
 				A0F6B9441F6E6EBB00220625 /* Array + Equatable.swift in Sources */,
+				83E6935A1FB3B3AE009A91C4 /* Data + toUtf8.swift in Sources */,
 				A0F6B9521F6E6EBB00220625 /* AtomFeedEntryContributor.swift in Sources */,
 				A0F6B96D1F6E6EBB00220625 /* MediaGroup.swift in Sources */,
 				A0F6B9701F6E6EBB00220625 /* MediaLocation.swift in Sources */,

--- a/Sources/FeedKit/Extensions/Data + toUtf8.swift
+++ b/Sources/FeedKit/Extensions/Data + toUtf8.swift
@@ -1,0 +1,38 @@
+//
+//  String + toUtf8.swift
+//
+//  Copyright (c) 2017 Nuno Manuel Dias
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+extension Data {
+
+    /// Detect encoding and convert data to UTF-8
+    func toUtf8() -> Data? {
+        var convertedString: NSString?
+        let encoding = NSString.stringEncoding(for: self, encodingOptions: nil, convertedString: &convertedString, usedLossyConversion: nil)
+        
+        guard let str = NSString(data: self, encoding: encoding) as String? else { return nil }
+        return str.data(using: .utf8)
+    }
+    
+}

--- a/Sources/FeedKit/Parser/FeedParser.swift
+++ b/Sources/FeedKit/Parser/FeedParser.swift
@@ -36,10 +36,12 @@ public class FeedParser {
     ///
     /// - Parameter data: An instance of `FeedParser`.
     public init?(data: Data) {
-        guard let feedDataType = FeedDataType(data: data) else { return nil }
+        guard let decoded = data.toUtf8() else { return nil }
+
+        guard let feedDataType = FeedDataType(data: decoded) else { return nil }
         switch feedDataType {
-        case .json: self.parser = JSONFeedParser(data: data)
-        case .xml:  self.parser = XMLFeedParser(data: data)
+        case .json: self.parser = JSONFeedParser(data: decoded)
+        case .xml:  self.parser = XMLFeedParser(data: decoded)
         }
     }
     


### PR DESCRIPTION
I was trying to parse a feed with FeedKit which kept failing because the encoding was not UTF-8 and one or more characters was preventing `String?` from loading it as UTF-8. The `FeedKit` object was always nil and never initialized.

You might think it is up to the app using FeedKit to convert its data to UTF-8 rather than FeedKit's responsibility but I thought I would submit a pull request anyway.