### PR TITLE
Faster and more robust feed type determination

### DIFF
--- a/Sources/FeedKit/Parser/FeedDataType.swift
+++ b/Sources/FeedKit/Parser/FeedDataType.swift
@@ -33,19 +33,39 @@ enum FeedDataType: String {
     case json
 }
 
+fileprivate let inspectionPrefixLength = 200
+
 extension FeedDataType {
     
     /// A `FeedDataType` from the specified `Data` object
     ///
     /// - Parameter data: The `Data` object.
     init?(data: Data) {
-        guard let string = String(data: data, encoding: .utf8) else { return nil }
-        guard let char = string.trimmingCharacters(in: .whitespacesAndNewlines).first else { return nil }
-        switch char {
-        case "<": self = .xml
-        case "{": self = .json
-        default: return nil
+        // As a practical matter, the dispositive characters will be found near
+        // the start of the buffer. It's expensive to convert the entire buffer to
+        // a string because the conversion is not lazy. So inspect only a prefix
+        // of the buffer.
+        let string = String(decoding: data.prefix(inspectionPrefixLength), as: UTF8.self)
+        let dispositiveCharacters = CharacterSet.alphanumerics
+            .union(CharacterSet.punctuationCharacters)
+            .union(CharacterSet.symbols)
+        for scalar in string.unicodeScalars {
+            if !dispositiveCharacters.contains(scalar) { // Skip whitespace, BOM marker if present
+                continue
+            }
+            let char = Character(scalar)
+            switch char {
+                case "<":
+                    self = .xml
+                    return
+                case "{":
+                    self = .json
+                    return
+                default:
+                    return nil
+            }
         }
+        return nil
     }
     
 }


### PR DESCRIPTION
Thanks for FeedKit! I'm using it in a podcasting app and it's been working like a champ. I have made a few of small tweaks that I'll upload as PRs. There's isn't really a general theme except perhaps that several of them have to do with [Postel's law](https://en.wikipedia.org/wiki/Robustness_principle) - they are adjustments to make out-of-compliance but sensible feeds less likely to fail parsing.

This first patch changes the implementation of XML vs. JSON determination, for a couple of reasons. 

First, XML needn't be in UTF-8 encoding, and I have seen cases where String(data:encoding:) actually fails because of this. String(decoding:as:) is a more lenient conversion and in this context it doesn't matter if odd characters are not correctly converted.

Second, there's no reason to convert the entire data block. Profiling was showing that this could be quite expensive with large feeds. If the feed doesn't show up within 200 characters, there's something very strange going on. 

Finally, instead of just trimming whitespace, this patch just defines clear sets of accept/reject/don't-care characters and acts on the first accept or reject character in the buffer.