### PR TITLE
Allow parsing from an InputStream containing XML

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ let feedURL = URL(string: "http://images.apple.com/main/rss/hotnews/hotnews.rss"
 
 Get an instance of `FeedParser`
 ```swift
-let parser = FeedParser(URL: feedURL) // or FeedParser(data: data)
+let parser = FeedParser(URL: feedURL) // or FeedParser(data: data) or FeedParser(xmlStream: stream)
 ```
 
 Then call `parse` or `parseAsync` to start parsing the feed...

--- a/Sources/FeedKit/Parser/FeedParser.swift
+++ b/Sources/FeedKit/Parser/FeedParser.swift
@@ -34,7 +34,7 @@ public class FeedParser {
     /// Initializes the parser with the xml or json contents encapsulated in a 
     /// given data object.
     ///
-    /// - Parameter data: An instance of `FeedParser`.
+    /// - Parameter data: XML or JSON data
     public init?(data: Data) {
         guard let feedDataType = FeedDataType(data: data) else { return nil }
         switch feedDataType {
@@ -43,9 +43,17 @@ public class FeedParser {
         }
     }
     
-    /// Initializes the parser with the XML content referenced by the given URL.
+    /// Initializes the parser with the XML contents encapsulated in a
+    /// given InputStream.
     ///
-    /// - Parameter URL: An instance of `FeedParser`.
+    /// - Parameter xmlStream: An InputStream that yields XML data.
+    public init(xmlStream: InputStream) {
+        self.parser = XMLFeedParser(stream: xmlStream)
+    }
+
+    /// Initializes the parser with the JSON or XML content referenced by the given URL.
+    ///
+    /// - Parameter URL: URL whose contents are read to produce the feed data
     public convenience init?(URL: URL) {
         guard let data = try? Data(contentsOf: URL) else {
             return nil

--- a/Sources/FeedKit/Parser/XMLFeedParser.swift
+++ b/Sources/FeedKit/Parser/XMLFeedParser.swift
@@ -51,6 +51,15 @@ class XMLFeedParser: NSObject, XMLParserDelegate, FeedParserProtocol {
         super.init()
         self.xmlParser.delegate = self
     }
+    
+    /// An XML Feed Parser, for rss and atom feeds.
+    ///
+    /// - Parameter stream: An `InputStream` object containing an XML feed.
+    init(stream: InputStream) {
+        self.xmlParser = XMLParser(stream: stream)
+        super.init()
+        self.xmlParser.delegate = self
+    }
 
     /// The current path along the XML's DOM elements. Path components are
     /// updated to reflect the current XML element being parsed.


### PR DESCRIPTION
This is kind of a weird backwater of the Apple API, but XMLParser can accept a Stream as input rather than a Data block. This is really nice in the case of FeedKit because it lets the download, the XML parsing, and the feed parsing all run concurrently. The time savings can be quite noticeable for large feeds. No other way of initializing an XMLParser gives this effect.

This patch adds a `FeedParser(xmlStream:)` initializer that propagates down to `XMLFeedParser(xmlStream:)`, bypassing format-type detection. 

Unfortunately, this isn't a complete solution on its own because you still need some way of getting a network data stream into the form of an InputStream, which as far as I can tell isn't a feature that's implemented in the Foundation API. I have some code that converts a URLSessionDataTask into a stream and I'd be happy to share it if you're interested, but it seems a bit peripheral to the core features of FeedKit. 

