### PR TITLE
Strip leading and trailing whitespace before parsing dates

### DIFF
--- a/Sources/FeedKit/Dates/ISO8601DateFormatter.swift
+++ b/Sources/FeedKit/Dates/ISO8601DateFormatter.swift
@@ -46,6 +46,7 @@ class ISO8601DateFormatter: DateFormatter {
     }
     
     override func date(from string: String) -> Date? {
+        let string = string.trimmingCharacters(in: .whitespacesAndNewlines)
         for dateFormat in self.dateFormats {
             self.dateFormat = dateFormat
             if let date = super.date(from: string) {

--- a/Sources/FeedKit/Dates/RFC3339DateFormatter.swift
+++ b/Sources/FeedKit/Dates/RFC3339DateFormatter.swift
@@ -45,6 +45,7 @@ class RFC3339DateFormatter: DateFormatter {
     }
     
     override func date(from string: String) -> Date? {
+        let string = string.trimmingCharacters(in: .whitespacesAndNewlines)
         for dateFormat in self.dateFormats {
             self.dateFormat = dateFormat
             if let date = super.date(from: string) {

--- a/Sources/FeedKit/Dates/RFC822DateFormatter.swift
+++ b/Sources/FeedKit/Dates/RFC822DateFormatter.swift
@@ -45,6 +45,7 @@ class RFC822DateFormatter: DateFormatter {
     }
     
     override func date(from string: String) -> Date? {
+        let string = string.trimmingCharacters(in: .whitespacesAndNewlines)
         for dateFormat in self.dateFormats {
             self.dateFormat = dateFormat
             if let date = super.date(from: string) {


### PR DESCRIPTION
Simple patch, just makes sure that date fields have no leading or trailing space before they get fed to DateFormatter. I have seen some feeds that have stray spaces that cause parsing to fail.