### PR TITLE
Make JSONFeed.init?(dictionary:) public

### DIFF
--- a/Sources/FeedKit/Models/JSON/JSONFeed.swift
+++ b/Sources/FeedKit/Models/JSON/JSONFeed.swift
@@ -115,7 +115,7 @@ public class JSONFeed {
 
 extension JSONFeed {
     
-    convenience init?(dictionary: [String : Any?]) {
+    public convenience init?(dictionary: [String : Any?]) {
         
         if dictionary.isEmpty {
             return nil


### PR DESCRIPTION
Makes possible to build a JSONFeed from an object which is already parsed by for example some networking library. Previously this couldn't be done because access-level was internal.