### PR TITLE
Date formatter Strings wrong

### DIFF
--- a/Sources/FeedKit/Dates/ISO8601DateFormatter.swift
+++ b/Sources/FeedKit/Dates/ISO8601DateFormatter.swift
@@ -29,10 +29,10 @@ import Foundation
 class ISO8601DateFormatter: DateFormatter {
     
     let dateFormats = [
-        "yyyy-mm-dd'T'hh:mm",
-        "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
         "yyyy-MM-dd'T'HH:mm:ss.SSZZZZZ",
-        "yyyy-MM-dd'T'HH:mmSSZZZZZ"
+        "yyyy-MM-dd'T'HH:mm:ssZZZZZ",
+        "yyyy-MM-dd'T'HH:mmSSZZZZZ",
+        "yyyy-MM-dd'T'HH:mm"
         ]
     
     override init() {


### PR DESCRIPTION
The isoformatter uses hh instead of HH and mm instead of MM in its first date format string. This can cause situations where months are read as minutes instead...