### PR TITLE
ADD - New Item "Creator"

### DIFF
--- a/FeedKit.podspec
+++ b/FeedKit.podspec
@@ -1,11 +1,12 @@
 Pod::Spec.new do |s|
-  s.name = 'FeedKit'
+  s.name = 'FeedKitMaximeKillinger'
   s.version = '8.0.0'
   s.license = 'MIT'
   s.summary = 'An RSS, Atom and JSON Feed parser written in Swift'
-  s.homepage = 'https://github.com/nmdias/FeedKit'
-  s.authors = { 'Nuno Manuel Dias' => 'nmdias.pt@gmail.com' }
-  s.source = { :git => 'https://github.com/nmdias/FeedKit.git', :tag => s.version }
+  s.homepage = 'https://github.com/maxime-killinger/FeedKit'
+  s.authors = { 'Nuno Manuel Dias' => 'nmdias.pt@gmail.com',
+                'Maxime Killinger' => 'max.killinger@outlook.fr'}
+  s.source = { :git => 'https://github.com/maxime-killinger/FeedKit', :tag => s.version }
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
   s.tvos.deployment_target = '9.0'

--- a/Sources/FeedKit/Models/RSS/RSSFeed + mapCharacters.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeed + mapCharacters.swift
@@ -70,6 +70,7 @@ extension RSSFeed {
         case .rssChannelItemLink:                                   self.items?.last?.link                                          = self.items?.last?.link?.appending(string) ?? string
         case .rssChannelItemDescription:                            self.items?.last?.description                                   = self.items?.last?.description?.appending(string) ?? string
         case .rssChannelItemAuthor:                                 self.items?.last?.author                                        = self.items?.last?.author?.appending(string) ?? string
+        case .rssChannelItemCreator:                                 self.items?.last?.creator                                        = self.items?.last?.creator?.appending(string) ?? string
         case .rssChannelItemCategory:                               self.items?.last?.categories?.last?.value                       = self.items?.last?.categories?.last?.value?.appending(string) ?? string
         case .rssChannelItemComments:                               self.items?.last?.comments                                      = self.items?.last?.comments?.appending(string) ?? string
         case .rssChannelItemGUID:                                   self.items?.last?.guid?.value                                   = self.items?.last?.guid?.value?.appending(string) ?? string

--- a/Sources/FeedKit/Models/RSS/RSSFeedItem.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeedItem.swift
@@ -67,6 +67,22 @@ public class RSSFeedItem {
     /// <author>lawyer@boyer.net (Lawyer Boyer)</author>
     public var author: String?
     
+    /// Name of the creator of the item.
+    ///
+    /// Example: Lawyer Boyer
+    ///
+    /// <creator> is an optional sub-element of <item>.
+    ///
+    /// It's the name of the creator of the item. For newspapers and
+    /// magazines syndicating via RSS, the creator is the person who wrote the
+    /// article that the <item> describes. For collaborative weblogs, the creator
+    /// of the item might be different from the managing editor or webmaster.
+    /// For a weblog authored by a single individual it would make sense to omit
+    /// the <creator> element.
+    ///
+    /// <creator>Lawyer Boyer</creator>
+    public var creator: String?
+    
     /// Includes the item in one or more categories.
     /// 
     /// <category> is an optional sub-element of <item>.
@@ -201,6 +217,7 @@ extension RSSFeedItem: Equatable {
     public static func ==(lhs: RSSFeedItem, rhs: RSSFeedItem) -> Bool {
         return
             lhs.author == rhs.author &&
+            lhs.creator == rhs.creator &&
             lhs.categories == rhs.categories &&
             lhs.comments == rhs.comments &&
             lhs.content == rhs.content &&

--- a/Sources/FeedKit/Models/RSS/RSSPath.swift
+++ b/Sources/FeedKit/Models/RSS/RSSPath.swift
@@ -67,6 +67,7 @@ enum RSSPath: String {
     case rssChannelItemLink                                     = "/rss/channel/item/link"
     case rssChannelItemDescription                              = "/rss/channel/item/description"
     case rssChannelItemAuthor                                   = "/rss/channel/item/author"
+    case rssChannelItemCreator                                  = "/rss/channel/item/creator"
     case rssChannelItemCategory                                 = "/rss/channel/item/category"
     case rssChannelItemComments                                 = "/rss/channel/item/comments"
     case rssChannelItemEnclosure                                = "/rss/channel/item/enclosure"

--- a/Tests/RSS2Tests.swift
+++ b/Tests/RSS2Tests.swift
@@ -47,7 +47,7 @@ class RSS2Tests: BaseTestCase {
         XCTAssertEqual(feed?.managingEditor, "john.appleseed.editor@iris.news (John Appleseed)")
         XCTAssertEqual(feed?.webMaster, "john.appleseed.master@iris.news (John Appleseed)")
         XCTAssertNotNil(feed?.pubDate)
-        XCTAssertNotNil(feed?.lastBuildDate)
+        XCTAssertNotNil(feed?.lastBuildDate)author
         
         XCTAssertNotNil(feed?.categories)
         XCTAssertEqual(feed?.categories?.count, 2)
@@ -119,7 +119,8 @@ class RSS2Tests: BaseTestCase {
         XCTAssertEqual(feed?.items?.first?.title, "Seventh Heaven! Ryan Hurls Another No Hitter")
         XCTAssertEqual(feed?.items?.first?.link, "http://dallas.example.com/1991/05/02/nolan.htm")
         XCTAssertEqual(feed?.items?.first?.author, "jbb@dallas.example.com (Joe Bob Briggs)")
-        
+        XCTAssertEqual(feed?.items?.first?.creator, "Joe Bob Briggs")
+
         XCTAssertNotNil(feed?.items?.first?.categories)
         XCTAssertEqual(feed?.items?.first?.categories?.count, 2)
         
@@ -154,7 +155,8 @@ class RSS2Tests: BaseTestCase {
         XCTAssertEqual(feed?.items?.last?.title, "Seventh Heaven! Ryan Hurls Another No Hitter")
         XCTAssertEqual(feed?.items?.last?.link, "http://dallas.example.com/1991/05/02/nolan.htm")
         XCTAssertEqual(feed?.items?.last?.author, "jbb@dallas.example.com (Joe Bob Briggs)")
-        
+        XCTAssertEqual(feed?.items?.last?.creator, "Joe Bob Briggs")
+
         XCTAssertNotNil(feed?.items?.last?.categories)
         XCTAssertEqual(feed?.items?.last?.categories?.count, 2)
         

--- a/Tests/xml/RSS2.xml
+++ b/Tests/xml/RSS2.xml
@@ -46,6 +46,7 @@
             <title>Seventh Heaven! Ryan Hurls Another No Hitter</title>
             <link>http://dallas.example.com/1991/05/02/nolan.htm</link>
             <author>jbb@dallas.example.com (Joe Bob Briggs)</author>
+            <creator>Joe Bob Briggs</creator>
             <category>movies</category>
             <category domain="rec.arts.movies.reviews">1983/V</category>
             <comments>http://dallas.example.com/feedback/1983/06/joebob.htm</comments>
@@ -59,6 +60,7 @@
             <title>Seventh Heaven! Ryan Hurls Another No Hitter</title>
             <link>http://dallas.example.com/1991/05/02/nolan.htm</link>
             <author>jbb@dallas.example.com (Joe Bob Briggs)</author>
+            <creator>Joe Bob Briggs</creator>
             <category>movies</category>
             <category domain="rec.arts.movies.reviews">1983/V</category>
             <comments>http://dallas.example.com/feedback/1983/06/joebob.htm</comments>


### PR DESCRIPTION
Add the item "creator" use for example in medium.com feed

"The dc:creator element identifies the person or entity who wrote an item (OPTIONAL). An item MAY contain more than one dc:creator element to credit multiple authors.

The creator can be identified using a real name, username or some other means of identification at the publisher's discretion."

http://www.rssboard.org/rss-profile#namespace-elements-dublin-creator

Signed-off-by: Maxime Killinger <max.killinger@outlook.fr>

modifié :         Sources/FeedKit/Models/RSS/RSSFeed + mapCharacters.swift
modifié :         Sources/FeedKit/Models/RSS/RSSFeedItem.swift
modifié :         Sources/FeedKit/Models/RSS/RSSPath.swift
modifié :         Tests/RSS2Tests.swift
modifié :         Tests/xml/RSS2.xml