### PR TITLE
fixes update and migration warnings in Xcode 10.3

### DIFF
--- a/FeedKit.xcodeproj/project.pbxproj
+++ b/FeedKit.xcodeproj/project.pbxproj
@@ -1375,7 +1375,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1030;
 				TargetAttributes = {
 					A0370EB81CEF9D5A009583A3 = {
 						CreatedOnToolsVersion = 7.3.1;

--- a/FeedKit.xcodeproj/project.pbxproj
+++ b/FeedKit.xcodeproj/project.pbxproj
@@ -1415,7 +1415,7 @@
 					};
 					A0EF4E0B1CE86D1E00C52142 = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = "";
+						LastSwiftMigration = 1030;
 						ProvisioningStyle = Manual;
 					};
 				};
@@ -2605,7 +2605,7 @@
 				PRODUCT_NAME = FeedKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -3697,7 +3697,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -3750,7 +3750,7 @@
 				PRODUCT_NAME = FeedKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/FeedKit.xcodeproj/project.pbxproj
+++ b/FeedKit.xcodeproj/project.pbxproj
@@ -1422,7 +1422,7 @@
 			};
 			buildConfigurationList = A0EF4D971CE867DF00C52142 /* Build configuration list for PBXProject "FeedKit" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit Example iOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit Example iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit Example macOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit Example macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit Example tvOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit Example tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit iOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit macOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit tvOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit watchOS.xcscheme
+++ b/FeedKit.xcodeproj/xcshareddata/xcschemes/FeedKit watchOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1030"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
There have been warnings for FeedKit in Xcode regarding
- migrating away from deprecated localization handling
- upgrading to newest recommended project settings
- upgrading to Swift 5.0

These commits fix these warnings. No code changes were necessary for the Swift 5.0 migration.