### PR TITLE
Trim white space in iTunesDuration parsing

### DIFF
--- a/Sources/FeedKit/Extensions/String + toDuration.swift
+++ b/Sources/FeedKit/Extensions/String + toDuration.swift
@@ -30,7 +30,9 @@ extension String {
     ///
     /// - Returns: A TimeInterval.
     func toDuration() -> TimeInterval? {
-        let comps = self.components(separatedBy: ":")
+        let comps = self
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: ":")
 
         guard
             !comps.contains(where: { Int($0) == nil }),


### PR DESCRIPTION
Occasionally I've found some RSS podcast feeds where there is some extra whitespace in the duration. (E.g., parsing " 1:07:03" fails)