### PR TITLE
Removed image URL appending

### DIFF
--- a/Sources/FeedKit/Models/RSS/RSSFeed + mapCharacters.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeed + mapCharacters.swift
@@ -48,9 +48,9 @@ extension RSSFeed {
         case .rssChannelDocs:                                       self.docs                                                       = self.docs?.appending(string) ?? string
         case .rssChannelRating:                                     self.rating                                                     = self.rating?.appending(string) ?? string
         case .rssChannelTTL:                                        self.ttl                                                        = Int(string)
-        case .rssChannelImageURL:                                   self.image?.url                                                 = self.image?.url?.appending(string) ?? string
+        case .rssChannelImageURL:                                   self.image?.url                                                 = string
         case .rssChannelImageTitle:                                 self.image?.title                                               = self.image?.title?.appending(string) ?? string
-        case .rssChannelImageLink:                                  self.image?.link                                                = self.image?.link?.appending(string) ?? string
+        case .rssChannelImageLink:                                  self.image?.link                                                = string
         case .rssChannelImageWidth:                                 self.image?.width                                               = Int(string)
         case .rssChannelImageHeight:                                self.image?.height                                              = Int(string)
         case .rssChannelImageDescription:                           self.image?.description                                         = self.image?.description?.appending(string) ?? string


### PR DESCRIPTION
Currently the parser is appending image urls to an existing image url if one exists. This leads to setting the field as `http://example.com/image.pnghttp://example.com/image2.png` if there are multiple images listed for the feed. This change makes it so the image URL field gets replaced, instead of getting appended to, whenever it finds a new image.

Example of where this happens: https://caneandrinse.com/feed/podcast/

Another alternative would be to add/change an `var images: [RSSFeedImage]` field.