### PR TITLE
adds FoundationNetworking import for linux

### DIFF
--- a/Sources/FeedKit/Parser/FeedParser.swift
+++ b/Sources/FeedKit/Parser/FeedParser.swift
@@ -24,6 +24,9 @@
 
 import Foundation
 import Dispatch
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// An RSS and Atom feed parser. `FeedParser` uses `Foundation`'s `XMLParser`.
 public class FeedParser {


### PR DESCRIPTION
fixes issues I was experiencing on Ubuntu 18.04 with Swift 5.2 (see issue #115)