### PR TITLE
Conform Feed and ParserError to Equatable

### DIFF
--- a/Sources/FeedKit/Parser/Feed.swift
+++ b/Sources/FeedKit/Parser/Feed.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public enum Feed {
+public enum Feed: Equatable {
     case atom(AtomFeed)
     case rss(RSSFeed)
     case json(JSONFeed)
@@ -35,27 +35,18 @@ public enum Feed {
 extension Feed {
     
     public var rssFeed: RSSFeed? {
-        switch self {
-        case .rss(let rssFeed): return rssFeed
-        case .atom(_): return nil
-        case .json(_): return nil
-        }
+        guard case let .rss(feed) = self else { return nil }
+        return feed
     }
 
     public var atomFeed: AtomFeed? {
-        switch self {
-        case .rss(_): return nil
-        case .atom(let atomFeed): return atomFeed
-        case .json(_): return nil
-        }
+        guard case let .atom(feed) = self else { return nil }
+        return feed
     }
 
     public var jsonFeed: JSONFeed? {
-        switch self {
-        case .rss(_): return nil
-        case .atom(_): return nil
-        case .json(let jsonFeed): return jsonFeed
-        }
+        guard case let .json(feed) = self else { return nil }
+        return feed
     }
 
 }

--- a/Sources/FeedKit/Parser/ParserError.swift
+++ b/Sources/FeedKit/Parser/ParserError.swift
@@ -31,7 +31,7 @@ import Foundation
 /// - feedCDATABlockEncodingError: Unable to convert the bytes in `CDATABlock` 
 ///   to Unicode characters using the UTF-8 encoding.
 /// - internalError: An internal error from which the user cannot recover.
-public enum ParserError {
+public enum ParserError: Equatable {
     case feedNotFound
     case feedCDATABlockEncodingError(path: String)
     case internalError(reason: String)

--- a/Tests/ParserErrorTests.swift
+++ b/Tests/ParserErrorTests.swift
@@ -38,7 +38,7 @@ class ParserErrorTests: BaseTestCase {
         
         // Then
         switch result {
-        case .failure(let error): XCTAssertEqual(error.code, ParserError.feedNotFound.code)
+        case .failure(let error): XCTAssertEqual(error, .feedNotFound)
         case .success(_): XCTFail("Unexpected feed found")
         }
         


### PR DESCRIPTION
Hey there 👋 , first of all thanks for your work!

I've been using FeedKit in a side project of mine and while I was creating unit tests for types that uses/wraps a FeedParser I though about potential minor improvements.. that's why I'm opening this PR.
These are lightweight changes and there are no breaking changes derived from it. I hope to be contributing.

#### Changes
- `Conform ParserError to Equatable`. IMO it makes it easier for users to check parser errors through equality. It helps on tests as well.

```Swift
parser.parseAsync(queue: queue) { result in
   switch result {
      case let .success(feed): 
          // do something
      case let .failure(error):
         switch error {
             case .notFound: break
             case let .feedCDATABlockEncodingError(path): break
             case let .internalError(reason): break
         }
   }
}
```
-  Since all Feed associated types (AtomFeed, etc) already conform to Equatable, it's straightforward to also make Feed conform to Equatable. It allows comparing the equality of a feed without getting the associated value. This can be e.g. useful in tests:
```Swift
let feed = Feed.rss(RSSFeed())
XCTAssertEqual(try lastResult?.get(), feed)
```