### PR TITLE
Fix comment typos

### DIFF
--- a/Sources/FeedKit/Models/Namespaces/Media/MediaParam.swift
+++ b/Sources/FeedKit/Models/Namespaces/Media/MediaParam.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-/// Key-Value pairs with aditional parameters for the embeded Media.
+/// Key-Value pairs with additional parameters for the embedded Media.
 public class MediaParam {
     
     /// The element's attributes.

--- a/Sources/FeedKit/Models/Namespaces/Media/MediaTag.swift
+++ b/Sources/FeedKit/Models/Namespaces/Media/MediaTag.swift
@@ -27,7 +27,7 @@ import Foundation
 /// This element contains user-generated tags separated by commas in the decreasing 
 /// order of each tag's weight. Each tag can be assigned an integer weight in 
 /// tag_name:weight format. It's up to the provider to choose the way weight is 
-/// determined for a tag; for example, number of occurences can be one way to 
+/// determined for a tag; for example, number of occurrences can be one way to 
 /// decide weight of a particular tag. Default weight is 1.
 public class MediaTag {
     


### PR DESCRIPTION
Fixes two comment misspellings in `MediaParam.swift` and one in `MediaTag.swift`.