### PR TITLE
Provide implementation for reading <atom:link> on an RSS feed.

### DIFF
--- a/FeedKit.xcodeproj/project.pbxproj
+++ b/FeedKit.xcodeproj/project.pbxproj
@@ -487,6 +487,16 @@
 		BB394B7D223B368C00366193 /* AmpersandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB394B7C223B368C00366193 /* AmpersandTests.swift */; };
 		BB394B7E223B368C00366193 /* AmpersandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB394B7C223B368C00366193 /* AmpersandTests.swift */; };
 		BB394B7F223B368C00366193 /* AmpersandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB394B7C223B368C00366193 /* AmpersandTests.swift */; };
+		EA0743542A3DF3A600E78F98 /* AtomNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0743532A3DF3A600E78F98 /* AtomNamespace.swift */; };
+		EA0743552A3DF7B900E78F98 /* AtomNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0743532A3DF3A600E78F98 /* AtomNamespace.swift */; };
+		EA0743562A3DF7B900E78F98 /* AtomNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0743532A3DF3A600E78F98 /* AtomNamespace.swift */; };
+		EA0743572A3DF7BA00E78F98 /* AtomNamespace.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0743532A3DF3A600E78F98 /* AtomNamespace.swift */; };
+		EA0743592A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml in Resources */ = {isa = PBXBuildFile; fileRef = EA0743582A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml */; };
+		EA07435A2A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml in Resources */ = {isa = PBXBuildFile; fileRef = EA0743582A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml */; };
+		EA07435B2A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml in Resources */ = {isa = PBXBuildFile; fileRef = EA0743582A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml */; };
+		EA07435D2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA07435C2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift */; };
+		EA07435E2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA07435C2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift */; };
+		EA07435F2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA07435C2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -723,6 +733,9 @@
 		A0F79FBC1F642AE2007CFC08 /* RDFTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RDFTests.swift; sourceTree = "<group>"; };
 		BB394B77223B35D700366193 /* Ampersand.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = Ampersand.xml; sourceTree = "<group>"; };
 		BB394B7C223B368C00366193 /* AmpersandTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AmpersandTests.swift; sourceTree = "<group>"; };
+		EA0743532A3DF3A600E78F98 /* AtomNamespace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomNamespace.swift; sourceTree = "<group>"; };
+		EA0743582A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = WebSubRSSFeedDiscovery.xml; sourceTree = "<group>"; };
+		EA07435C2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSFeedDiscoveryTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -825,6 +838,7 @@
 				A09AFB391EEFDFF40076ACC7 /* SyndicationTests.swift */,
 				BB394B7C223B368C00366193 /* AmpersandTests.swift */,
 				A0C788BE20CC5606005C2F6F /* FeedUriSchemeSanitizerTests.swift */,
+				EA07435C2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift */,
 				A09AFB5E1EEFE0060076ACC7 /* Info.plist */,
 			);
 			path = Tests;
@@ -991,6 +1005,7 @@
 		A0F6B7E51F6E6E9600220625 /* Namespaces */ = {
 			isa = PBXGroup;
 			children = (
+				EA0743522A3DF39400E78F98 /* Atom */,
 				A0F6B7E61F6E6E9600220625 /* Content */,
 				A0F6B7E81F6E6E9600220625 /* Dublin Core */,
 				A0F6B7EA1F6E6E9600220625 /* iTunes */,
@@ -1121,6 +1136,7 @@
 		A0F6B9AD1F6E6FA700220625 /* xml */ = {
 			isa = PBXGroup;
 			children = (
+				EA0743582A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml */,
 				BB394B77223B35D700366193 /* Ampersand.xml */,
 				A0F6B9AE1F6E6FA700220625 /* Atom.xml */,
 				A0F6B9AF1F6E6FA700220625 /* AtomMedia.xml */,
@@ -1153,6 +1169,14 @@
 				A0F6B9BE1F6E6FC700220625 /* FeedTableViewController.swift */,
 			);
 			path = "View Controllers";
+			sourceTree = "<group>";
+		};
+		EA0743522A3DF39400E78F98 /* Atom */ = {
+			isa = PBXGroup;
+			children = (
+				EA0743532A3DF3A600E78F98 /* AtomNamespace.swift */,
+			);
+			path = Atom;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1473,6 +1497,7 @@
 				A0F6B9D81F6E713F00220625 /* FeedNotFound.xml in Resources */,
 				A0F6B9D91F6E713F00220625 /* iTunesPodcasting.xml in Resources */,
 				A0F6B9DE1F6E713F00220625 /* RSSMedia.xml in Resources */,
+				EA0743592A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml in Resources */,
 				BB394B79223B362300366193 /* Ampersand.xml in Resources */,
 				A0F6B9D71F6E713F00220625 /* Content.xml in Resources */,
 				A0F6B9D51F6E713F00220625 /* Atom.xml in Resources */,
@@ -1493,6 +1518,7 @@
 				A0F6B9CD1F6E713F00220625 /* FeedNotFound.xml in Resources */,
 				A0F6B9CE1F6E713F00220625 /* iTunesPodcasting.xml in Resources */,
 				A0F6B9D31F6E713F00220625 /* RSSMedia.xml in Resources */,
+				EA07435A2A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml in Resources */,
 				BB394B7A223B362400366193 /* Ampersand.xml in Resources */,
 				A0F6B9CC1F6E713F00220625 /* Content.xml in Resources */,
 				A0F6B9CA1F6E713F00220625 /* Atom.xml in Resources */,
@@ -1513,6 +1539,7 @@
 				A0F6B9C21F6E713E00220625 /* FeedNotFound.xml in Resources */,
 				A0F6B9C31F6E713E00220625 /* iTunesPodcasting.xml in Resources */,
 				A0F6B9C81F6E713F00220625 /* RSSMedia.xml in Resources */,
+				EA07435B2A3DF86B00E78F98 /* WebSubRSSFeedDiscovery.xml in Resources */,
 				BB394B7B223B362400366193 /* Ampersand.xml in Resources */,
 				A0F6B9C11F6E713E00220625 /* Content.xml in Resources */,
 				A0F6B9BF1F6E713E00220625 /* Atom.xml in Resources */,
@@ -1593,6 +1620,7 @@
 				A0F6B8531F6E6EB800220625 /* MediaCommunity.swift in Sources */,
 				A0F6B8731F6E6EB800220625 /* RSSFeed.swift in Sources */,
 				A0F6B86F1F6E6EB800220625 /* SyndicationUpdatePeriod.swift in Sources */,
+				EA0743572A3DF7BA00E78F98 /* AtomNamespace.swift in Sources */,
 				A0F6B87B1F6E6EB800220625 /* RSSFeedItemSource.swift in Sources */,
 				A0F6B8321F6E6EB800220625 /* String + toDate.swift in Sources */,
 				A0F6B8861F6E6EB800220625 /* XMLFeedParser.swift in Sources */,
@@ -1686,6 +1714,7 @@
 				A0F79FBD1F642AE2007CFC08 /* RDFTests.swift in Sources */,
 				A09AFB3A1EEFDFF40076ACC7 /* AtomTests.swift in Sources */,
 				A09AFB401EEFDFF40076ACC7 /* ContentTests.swift in Sources */,
+				EA07435D2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift in Sources */,
 				A09AFB491EEFDFF40076ACC7 /* DurationTests.swift in Sources */,
 				A09AFB431EEFDFF40076ACC7 /* DateTests.swift in Sources */,
 				A09AFB461EEFDFF40076ACC7 /* DublinCoreTests.swift in Sources */,
@@ -1708,6 +1737,7 @@
 				A0F79FBE1F642AE2007CFC08 /* RDFTests.swift in Sources */,
 				A09AFB3B1EEFDFF40076ACC7 /* AtomTests.swift in Sources */,
 				A09AFB411EEFDFF40076ACC7 /* ContentTests.swift in Sources */,
+				EA07435E2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift in Sources */,
 				A09AFB4A1EEFDFF40076ACC7 /* DurationTests.swift in Sources */,
 				A09AFB441EEFDFF40076ACC7 /* DateTests.swift in Sources */,
 				A09AFB471EEFDFF40076ACC7 /* DublinCoreTests.swift in Sources */,
@@ -1730,6 +1760,7 @@
 				A0F79FBF1F642AE2007CFC08 /* RDFTests.swift in Sources */,
 				A09AFB3C1EEFDFF40076ACC7 /* AtomTests.swift in Sources */,
 				A09AFB421EEFDFF40076ACC7 /* ContentTests.swift in Sources */,
+				EA07435F2A3DF8A800E78F98 /* RSSFeedDiscoveryTest.swift in Sources */,
 				A09AFB4B1EEFDFF40076ACC7 /* DurationTests.swift in Sources */,
 				A09AFB451EEFDFF40076ACC7 /* DateTests.swift in Sources */,
 				A09AFB481EEFDFF40076ACC7 /* DublinCoreTests.swift in Sources */,
@@ -1789,6 +1820,7 @@
 				A0F6B90B1F6E6EBB00220625 /* MediaCommunity.swift in Sources */,
 				A0F6B92B1F6E6EBB00220625 /* RSSFeed.swift in Sources */,
 				A0F6B9271F6E6EBB00220625 /* SyndicationUpdatePeriod.swift in Sources */,
+				EA0743552A3DF7B900E78F98 /* AtomNamespace.swift in Sources */,
 				A0F6B9331F6E6EBB00220625 /* RSSFeedItemSource.swift in Sources */,
 				A0F6B8EA1F6E6EBA00220625 /* String + toDate.swift in Sources */,
 				A0F6B93E1F6E6EBB00220625 /* XMLFeedParser.swift in Sources */,
@@ -1889,6 +1921,7 @@
 				A0F6B8AF1F6E6EBA00220625 /* MediaCommunity.swift in Sources */,
 				A0F6B8CF1F6E6EBA00220625 /* RSSFeed.swift in Sources */,
 				A0F6B8CB1F6E6EBA00220625 /* SyndicationUpdatePeriod.swift in Sources */,
+				EA0743562A3DF7B900E78F98 /* AtomNamespace.swift in Sources */,
 				A0F6B8D71F6E6EBA00220625 /* RSSFeedItemSource.swift in Sources */,
 				A0F6B88E1F6E6EBA00220625 /* String + toDate.swift in Sources */,
 				A0F6B8E21F6E6EBA00220625 /* XMLFeedParser.swift in Sources */,
@@ -1989,6 +2022,7 @@
 				A0F6B9671F6E6EBB00220625 /* MediaCommunity.swift in Sources */,
 				A0F6B9871F6E6EBB00220625 /* RSSFeed.swift in Sources */,
 				A0F6B9831F6E6EBB00220625 /* SyndicationUpdatePeriod.swift in Sources */,
+				EA0743542A3DF3A600E78F98 /* AtomNamespace.swift in Sources */,
 				A0F6B98F1F6E6EBB00220625 /* RSSFeedItemSource.swift in Sources */,
 				A0F6B9461F6E6EBB00220625 /* String + toDate.swift in Sources */,
 				A0F6B99A1F6E6EBB00220625 /* XMLFeedParser.swift in Sources */,

--- a/Sources/FeedKit/Models/Namespaces/Atom/AtomNamespace.swift
+++ b/Sources/FeedKit/Models/Namespaces/Atom/AtomNamespace.swift
@@ -1,0 +1,48 @@
+//
+//  AtomNamespace.swift
+//
+//  Copyright (c) 2023 Naufal Fachrian
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+/// Atom namespace in an RSS feed helps WebSub subscribers discover the topic
+/// and hub information.
+/// See https://www.w3.org/TR/websub/#discovery
+public class AtomNamespace {
+    
+    /// The "atom:link" element defines a reference from an entry or feed to
+    /// a Web resource.
+    public var links: [AtomFeedLink]?
+    
+    public init() { }
+    
+}
+
+// MARK: - Equatable
+
+extension AtomNamespace: Equatable {
+    
+    public static func ==(lhs: AtomNamespace, rhs: AtomNamespace) -> Bool {
+        return lhs.links == rhs.links
+    }
+    
+}

--- a/Sources/FeedKit/Models/RSS/RSSFeed + mapAttributes.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeed + mapAttributes.swift
@@ -492,6 +492,26 @@ extension RSSFeed {
             default: break
                 
             }
+            
+        case .rssChannelAtomLink:
+            
+            if self.atom == nil {
+                self.atom = AtomNamespace()
+            }
+            
+            switch path {
+                
+            case .rssChannelAtomLink:
+                
+                if self.atom?.links == nil {
+                    self.atom?.links = []
+                }
+                
+                self.atom?.links?.append(AtomFeedLink(attributes: attributes))
+                
+            default: break
+                
+            }
 
             
         default: break

--- a/Sources/FeedKit/Models/RSS/RSSFeed.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeed.swift
@@ -250,6 +250,11 @@ public class RSSFeed {
     /// See https://help.apple.com/itc/podcasts_connect/#/itcb54353390
     public var iTunes: ITunesNamespace?
     
+    /// Atom namespace in an RSS feed helps WebSub subscribers discover the topic
+    /// and hub information.
+    /// See https://www.w3.org/TR/websub/#discovery
+    public var atom: AtomNamespace?
+    
     public init() { }
     
 }

--- a/Sources/FeedKit/Models/RSS/RSSFeed.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeed.swift
@@ -265,6 +265,7 @@ extension RSSFeed: Equatable {
     
     public static func ==(lhs: RSSFeed, rhs: RSSFeed) -> Bool {
         return
+            lhs.atom == rhs.atom &&
             lhs.categories == rhs.categories &&
             lhs.cloud == rhs.cloud &&
             lhs.copyright == rhs.copyright &&

--- a/Sources/FeedKit/Models/RSS/RSSPath.swift
+++ b/Sources/FeedKit/Models/RSS/RSSPath.swift
@@ -74,6 +74,10 @@ enum RSSPath: String {
     case rssChannelItemPubDate                                  = "/rss/channel/item/pubDate"
     case rssChannelItemSource                                   = "/rss/channel/item/source"
     
+    // Atom
+    
+    case rssChannelAtomLink                                     = "/rss/channel/atom:link"
+    
     // Content
     
     case rssChannelItemContentEncoded                           = "/rss/channel/item/content:encoded"

--- a/Tests/RSSFeedDiscoveryTest.swift
+++ b/Tests/RSSFeedDiscoveryTest.swift
@@ -1,0 +1,50 @@
+//
+//  RSSFeedDiscoveryTest.swift
+//
+//  Copyright (c) 2023 Naufal Fachrian
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import XCTest
+import FeedKit
+
+class RSSFeedDiscoveryTest: BaseTestCase {
+    
+    func testRSSFeedDiscoveryTest() {
+        
+        let URL = fileURL("WebSubRSSFeedDiscovery", type: "xml")
+        let parser = FeedParser(URL: URL)
+        
+        do {
+
+            let feed = try parser.parse().get().rssFeed
+            
+            XCTAssertNotNil(feed)
+            XCTAssertEqual(feed?.atom?.links?.count, 2)
+            XCTAssertEqual(feed?.atom?.links?.first { element in element.attributes?.rel == "self" }?.attributes?.href, "https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi")
+            XCTAssertEqual(feed?.atom?.links?.first { element in element.attributes?.rel == "hub" }?.attributes?.href, "https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi/hub")
+            
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+        
+    }
+    
+}

--- a/Tests/xml/WebSubRSSFeedDiscovery.xml
+++ b/Tests/xml/WebSubRSSFeedDiscovery.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<?xml-stylesheet type="text/xsl" href="https://websub.rocks/assets/rss.xsl" ?>
+<rss version="2.0"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:atom="http://www.w3.org/2005/Atom"
+  >
+<channel>
+  <title>WebSub Rocks! RSS Feed Discovery</title>
+  <atom:link href="https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi" rel="self" type="application/rss+xml" />
+  <atom:link href="https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi/hub" rel="hub" />
+  <link>https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi</link>
+  <publishUrl>https://websub.rocks/subscriber/103/lkK5Yax5utH3Ve5OUNQi/publish</publishUrl>
+  <lastBuildDate>Sat, 17 Jun 2023 13:53:20 +0000</lastBuildDate>
+  <language>en-US</language>
+  
+  <description>This RSS feed has a stylesheet that will make it look like the websub.rocks site. If you are seeing this message, your browser doesn't support XSLT. To add a new post to this feed, follow this link https://websub.rocks/subscriber/103/lkK5Yax5utH3Ve5OUNQi/publish</description>
+
+  
+    <item>
+      <title></title>
+      <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+      <guid isPermaLink="true">https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi#quote-0</guid>
+      <description><![CDATA[]]></description>
+      <link>https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi#quote-0</link>
+      <author></author>
+    </item>
+    
+  
+    <item>
+      <title></title>
+      <pubDate>Sat, 17 Jun 2023 13:53:20 +0000</pubDate>
+      <guid isPermaLink="true">https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi#quote-1</guid>
+      <description><![CDATA[Simply put, you believer that things or people make you unhappy, but this is not accurate. You make yourself unhappy.]]></description>
+      <link>https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi#quote-1</link>
+      <author>Wayne Dyer</author>
+    </item>
+    
+  
+    <item>
+      <title></title>
+      <pubDate>Sat, 17 Jun 2023 13:53:20 +0000</pubDate>
+      <guid isPermaLink="true">https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi#quote-2</guid>
+      <description><![CDATA[Being angry never solves anything.]]></description>
+      <link>https://websub.rocks/blog/103/lkK5Yax5utH3Ve5OUNQi#quote-2</link>
+      <author>Catherine Pulsifer</author>
+    </item>
+    
+  </channel>
+</rss>


### PR DESCRIPTION
This PR provide implementation for reading <atom:link> on an RSS feed. <atom:link> in an RSS feed helps WebSub subscribers discover the topic and hub information.

See 
https://www.w3.org/TR/websub/#discovery 

This PR could also useful outside WebSub scenario and fulfill the request on issue #134 