### PR TITLE
Public Init for AtomFeedEntryLink, JsonFeed, JsonFeedItem

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/Sources/FeedKit/Models/Atom/AtomFeedEntryLink.swift
+++ b/Sources/FeedKit/Models/Atom/AtomFeedEntryLink.swift
@@ -36,6 +36,9 @@ public class AtomFeedEntryLink {
         /// have an href attribute, whose value MUST be a IRI reference
         /// [RFC3987].
         public var href: String?
+
+        public init() {
+        }
         
         /// The atom:link elements MAY have a "rel" attribute that indicates the link
         /// relation type.  If the "rel" attribute is not present, the link
@@ -132,7 +135,7 @@ public class AtomFeedEntryLink {
 
 extension AtomFeedEntryLink {
     
-    convenience init(attributes attributeDict: [String : String]) {
+    public convenience init(attributes attributeDict: [String : String]) {
         self.init()
         self.attributes = AtomFeedEntryLink.Attributes(attributes: attributeDict)
     }
@@ -141,7 +144,7 @@ extension AtomFeedEntryLink {
 
 extension AtomFeedEntryLink.Attributes {
     
-    convenience init?(attributes attributeDict: [String : String]) {
+    public convenience init?(attributes attributeDict: [String : String]) {
         
         if attributeDict.isEmpty {
             return nil

--- a/Sources/FeedKit/Models/JSON/JSONFeed.swift
+++ b/Sources/FeedKit/Models/JSON/JSONFeed.swift
@@ -101,7 +101,21 @@ public struct JSONFeed {
     
     /// The JSONFeed items.
     public var items: [JSONFeedItem]?
-    
+
+    public init(version: String? = nil, title: String? = nil, homePageURL: String? = nil, feedUrl: String? = nil, description: String? = nil, userComment: String? = nil, nextUrl: String? = nil, icon: String? = nil, favicon: String? = nil) {
+        self.version = version
+        self.title = title
+        self.homePageURL = homePageURL
+        self.feedUrl = feedUrl
+        self.description = description
+        self.userComment = userComment
+        self.nextUrl = nextUrl
+        self.icon = icon
+        self.favicon = favicon
+    }
+
+
+
 }
 
 // MARK: - Equatable

--- a/Sources/FeedKit/Models/JSON/JSONFeedItem.swift
+++ b/Sources/FeedKit/Models/JSON/JSONFeedItem.swift
@@ -104,6 +104,23 @@ public struct JSONFeedItem {
     
     /// (optional, array) lists related resources.
     public var attachments: [JSONFeedAttachment]?
+
+    public init(id: String? = nil, url: String? = nil, externalUrl: String? = nil, title: String? = nil, contentText: String? = nil, contentHtml: String? = nil, summary: String? = nil, image: String? = nil, bannerImage: String? = nil, datePublished: Date? = nil, dateModified: Date? = nil, author: JSONFeedAuthor? = nil, tags: [String]? = nil, attachments: [JSONFeedAttachment]? = nil) {
+        self.id = id
+        self.url = url
+        self.externalUrl = externalUrl
+        self.title = title
+        self.contentText = contentText
+        self.contentHtml = contentHtml
+        self.summary = summary
+        self.image = image
+        self.bannerImage = bannerImage
+        self.datePublished = datePublished
+        self.dateModified = dateModified
+        self.author = author
+        self.tags = tags
+        self.attachments = attachments
+    }
     
 }
 


### PR DESCRIPTION
Public init for a certain class would be beneficial, as it would allow us to easily mock and test without relying on an XML file or directly injecting variables into FeedKit.