### PR TITLE
Fix issue where iTunes namespace are not properly initialized.

### DIFF
--- a/Sources/FeedKit/Models/RSS/RSSFeed + mapAttributes.swift
+++ b/Sources/FeedKit/Models/RSS/RSSFeed + mapAttributes.swift
@@ -226,8 +226,11 @@ extension RSSFeed {
         .rssChannelItemItunesTitle,
         .rssChannelItemItunesSubtitle,
         .rssChannelItemItunesSummary,
-        .rssChannelItemItunesKeywords:
-            
+        .rssChannelItemItunesKeywords,
+        .rssChannelItemItunesSeason,
+        .rssChannelItemItunesEpisode,
+        .rssChannelItemItunesEpisodeType:
+
             if  self.items?.last?.iTunes == nil {
                 self.items?.last?.iTunes = ITunesNamespace()
             }


### PR DESCRIPTION
If `itunes:season`, `itunes:episodoe` or `itunes:episodeType` are the first itunes attributes in the item, then those values will be lost during parsing since the `iTunes` filed will not be initialized yet.