### PR TITLE
Coerce Int ids to String

### DIFF
--- a/Sources/FeedKit/Models/JSON/JSONFeedItem.swift
+++ b/Sources/FeedKit/Models/JSON/JSONFeedItem.swift
@@ -152,6 +152,12 @@ extension JSONFeedItem: Codable {
     
     public init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
+        do {
+            id = try values.decode(String.self, forKey: .id)
+        } catch DecodingError.typeMismatch {
+            let idInt = try values.decode(Int.self, forKey: .id)
+            id = String(describing: idInt)
+        }
         id = try values.decodeIfPresent(String.self, forKey: .id)
         title = try values.decodeIfPresent(String.self, forKey: .title)
         url = try values.decodeIfPresent(String.self, forKey: .url)

--- a/Sources/FeedKit/Models/JSON/JSONFeedItem.swift
+++ b/Sources/FeedKit/Models/JSON/JSONFeedItem.swift
@@ -158,7 +158,6 @@ extension JSONFeedItem: Codable {
             let idInt = try values.decode(Int.self, forKey: .id)
             id = String(describing: idInt)
         }
-        id = try values.decodeIfPresent(String.self, forKey: .id)
         title = try values.decodeIfPresent(String.self, forKey: .title)
         url = try values.decodeIfPresent(String.self, forKey: .url)
         externalUrl = try values.decodeIfPresent(String.self, forKey: .external_url)


### PR DESCRIPTION
According to the JSON Feed specification (https://www.jsonfeed.org/version/1/), item ids should be coerced to strings:

> id (required, string) is unique for that item for that feed over time. If an item is ever updated, the id should be unchanged. New items should never use a previously-used id. If an id is presented as a number or other type, a JSON Feed reader must coerce it to a string

The init method is thus changed to detect an invalid encoding and try an alternate type instead.