### PR TITLE
Allow the use of a custom date format - parsing and generating

### DIFF
--- a/Sources/FeedKit/FeedDateFormatter.swift
+++ b/Sources/FeedKit/FeedDateFormatter.swift
@@ -217,6 +217,7 @@ enum DateSpec {
   /// Permissive mode which attempts to parse the date using multiple formats.
   /// It tries RFC822 first, then RFC3339, RFC1123 and finally ISO8601 in that order.
   case permissive
+  case custom(DateFormatter)
 }
 
 // MARK: - FeedDateFormatter
@@ -275,6 +276,8 @@ class FeedDateFormatter: DateFormatter, @unchecked Sendable {
         rfc3339Formatter.date(from: string) ??
         rfc1123Formatter.date(from: string) ??
         iso8601Formatter.date(from: string)
+    case .custom(let formatter):
+      formatter.date(from: string)
     }
   }
 
@@ -295,6 +298,8 @@ class FeedDateFormatter: DateFormatter, @unchecked Sendable {
       rfc1123Formatter.string(from: date)
     case .permissive:
       fatalError()
+    case .custom(let formatter):
+      formatter.string(from: date)
     }
   }
 }

--- a/Sources/FeedKit/FeedInitializable.swift
+++ b/Sources/FeedKit/FeedInitializable.swift
@@ -31,32 +31,38 @@ import XMLKit
 public protocol FeedInitializable: Codable {
   /// Initializes from a URL string pointing to a feed.
   /// - Parameter urlString: The URL string of the feed.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if the URL string is invalid or loading fails.
-  init(urlString: String) async throws
+  init(urlString: String, customDateFormatter: DateFormatter?) async throws
 
   /// Initializes from a URL pointing to a feed.
   /// - Parameter url: The URL of the feed.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if the URL is invalid or loading fails.
-  init(url: URL) async throws
+  init(url: URL, customDateFormatter: DateFormatter?) async throws
 
   /// Initializes from a file URL.
   /// - Parameter url: The local file URL of the feed.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if the file cannot be read or parsed.
-  init(fileURL url: URL) throws
+  init(fileURL url: URL, customDateFormatter: DateFormatter?) throws
   /// Initializes from a remote URL.
   /// - Parameter url: The remote URL of the feed.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if fetching or parsing fails.
-  init(remoteURL url: URL) async throws
+  init(remoteURL url: URL, customDateFormatter: DateFormatter?) async throws
 
   /// Initializes from a string.
   /// - Parameter string: The feed content as a string.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if the string cannot be parsed.
-  init(string: String) throws
+  init(string: String, customDateFormatter: DateFormatter?) throws
 
   /// Initializes from data.
   /// - Parameter data: The feed content as raw data.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if the data cannot be parsed.
-  init(data: Data) throws
+  init(data: Data, customDateFormatter: DateFormatter?) throws
 }
 
 // MARK: - Default
@@ -64,37 +70,40 @@ public protocol FeedInitializable: Codable {
 public extension FeedInitializable {
   /// Default implementation for initializing from a URL string.
   /// - Parameter urlString: The URL string of the feed.
+  /// - Parameter customDateFormat The optional string that defines weird date formats
   /// - Throws: An error if the feed cannot be loaded or parsed.
-  init(urlString: String) async throws {
+  init(urlString: String, customDateFormatter: DateFormatter? = nil) async throws {
     guard let url = URL(string: urlString) else {
       throw FeedError.invalidURLString
     }
-    try await self.init(url: url)
+    try await self.init(url: url, customDateFormatter: customDateFormatter)
   }
 
   /// Default implementation for initializing from a URL.
   /// - Parameter url: The URL of the feed.
   /// - Throws: An error if the feed cannot be loaded or parsed.
-  init(url: URL) async throws {
+  init(url: URL, customDateFormatter: DateFormatter? = nil) async throws {
     if url.isFileURL {
-      try self.init(fileURL: url)
+      try self.init(fileURL: url, customDateFormatter: customDateFormatter)
     } else {
-      try await self.init(remoteURL: url)
+      try await self.init(remoteURL: url, customDateFormatter: customDateFormatter)
     }
   }
 
   /// Initializes from a file URL.
   /// - Parameter url: The local file URL of the feed.
+  /// - Parameter url: The URL of the feed.
   /// - Throws: An error if the file cannot be read or parsed.
-  init(fileURL url: URL) throws {
+  init(fileURL url: URL, customDateFormatter: DateFormatter? = nil) throws {
     let data = try Data(contentsOf: url)
-    try self.init(data: data)
+    try self.init(data: data, customDateFormatter: customDateFormatter)
   }
 
   /// Initializes from a remote URL.
   /// - Parameter url: The remote URL of the feed.
+  /// - Parameter url: The URL of the feed.
   /// - Throws: An error if fetching or parsing fails.
-  init(remoteURL url: URL) async throws {
+  init(remoteURL url: URL, customDateFormatter: DateFormatter? = nil) async throws {
     let session: URLSession = .shared
     let (data, response) = try await session.data(from: url)
 
@@ -107,24 +116,26 @@ public extension FeedInitializable {
       throw FeedError.invalidHttpResponse(statusCode: statusCode)
     }
 
-    try self.init(data: data)
+    try self.init(data: data, customDateFormatter: customDateFormatter)
   }
 
   /// Default implementation for initializing from a string.
   /// - Parameter string: The feed content as a string.
+  /// - Parameter url: The URL of the feed.
   /// - Throws: An error if the string cannot be converted to data or parsed.
-  init(string: String) throws {
+  init(string: String, customDateFormatter: DateFormatter? = nil) throws {
     guard let data = string.data(using: .utf8) else {
       throw FeedError.invalidUtf8String
     }
-    try self.init(data: data)
+    try self.init(data: data, customDateFormatter: customDateFormatter)
   }
 
   /// Default implementation for initializing from data.
   /// - Parameter data: The feed content as raw data.
+  /// - Parameter url: The URL of the feed.
   /// - Throws: An error if parsing or decoding fails.
-  init(data: Data) throws {
-    self = try Self.decode(data: data)
+  init(data: Data, customDateFormatter: DateFormatter? = nil) throws {
+    self = try Self.decode(data: data, customDateFormatter: customDateFormatter)
   }
 }
 
@@ -134,9 +145,9 @@ extension FeedInitializable {
   /// Helper method for decoding data into a model.
   /// - Parameter data: The raw feed data.
   /// - Returns: A parsed feed model conforming to `FeedInitializable`.
-  private static func decode(data: Data) throws -> Self {
+  private static func decode(data: Data, customDateFormatter: DateFormatter? = nil) throws -> Self {
     let decoder: XMLDecoder = .init()
-    let formatter: FeedDateFormatter = .init(spec: .permissive)
+    let formatter: FeedDateFormatter = .init(spec: customDateFormatter == nil ? .permissive : .custom(customDateFormatter!))
     decoder.dateDecodingStrategy = .formatter(formatter)
     return try decoder.decode(Self.self, from: data)
   }

--- a/Sources/FeedKit/FeedInitializable.swift
+++ b/Sources/FeedKit/FeedInitializable.swift
@@ -31,36 +31,36 @@ import XMLKit
 public protocol FeedInitializable: Codable {
   /// Initializes from a URL string pointing to a feed.
   /// - Parameter urlString: The URL string of the feed.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the URL string is invalid or loading fails.
   init(urlString: String, customDateFormatter: DateFormatter?) async throws
 
   /// Initializes from a URL pointing to a feed.
   /// - Parameter url: The URL of the feed.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the URL is invalid or loading fails.
   init(url: URL, customDateFormatter: DateFormatter?) async throws
 
   /// Initializes from a file URL.
   /// - Parameter url: The local file URL of the feed.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the file cannot be read or parsed.
   init(fileURL url: URL, customDateFormatter: DateFormatter?) throws
   /// Initializes from a remote URL.
   /// - Parameter url: The remote URL of the feed.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if fetching or parsing fails.
   init(remoteURL url: URL, customDateFormatter: DateFormatter?) async throws
 
   /// Initializes from a string.
   /// - Parameter string: The feed content as a string.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the string cannot be parsed.
   init(string: String, customDateFormatter: DateFormatter?) throws
 
   /// Initializes from data.
   /// - Parameter data: The feed content as raw data.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the data cannot be parsed.
   init(data: Data, customDateFormatter: DateFormatter?) throws
 }
@@ -70,7 +70,7 @@ public protocol FeedInitializable: Codable {
 public extension FeedInitializable {
   /// Default implementation for initializing from a URL string.
   /// - Parameter urlString: The URL string of the feed.
-  /// - Parameter customDateFormat The optional string that defines weird date formats
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the feed cannot be loaded or parsed.
   init(urlString: String, customDateFormatter: DateFormatter? = nil) async throws {
     guard let url = URL(string: urlString) else {
@@ -81,6 +81,7 @@ public extension FeedInitializable {
 
   /// Default implementation for initializing from a URL.
   /// - Parameter url: The URL of the feed.
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the feed cannot be loaded or parsed.
   init(url: URL, customDateFormatter: DateFormatter? = nil) async throws {
     if url.isFileURL {
@@ -92,7 +93,7 @@ public extension FeedInitializable {
 
   /// Initializes from a file URL.
   /// - Parameter url: The local file URL of the feed.
-  /// - Parameter url: The URL of the feed.
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the file cannot be read or parsed.
   init(fileURL url: URL, customDateFormatter: DateFormatter? = nil) throws {
     let data = try Data(contentsOf: url)
@@ -101,7 +102,7 @@ public extension FeedInitializable {
 
   /// Initializes from a remote URL.
   /// - Parameter url: The remote URL of the feed.
-  /// - Parameter url: The URL of the feed.
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if fetching or parsing fails.
   init(remoteURL url: URL, customDateFormatter: DateFormatter? = nil) async throws {
     let session: URLSession = .shared
@@ -121,7 +122,7 @@ public extension FeedInitializable {
 
   /// Default implementation for initializing from a string.
   /// - Parameter string: The feed content as a string.
-  /// - Parameter url: The URL of the feed.
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if the string cannot be converted to data or parsed.
   init(string: String, customDateFormatter: DateFormatter? = nil) throws {
     guard let data = string.data(using: .utf8) else {
@@ -132,7 +133,7 @@ public extension FeedInitializable {
 
   /// Default implementation for initializing from data.
   /// - Parameter data: The feed content as raw data.
-  /// - Parameter url: The URL of the feed.
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Throws: An error if parsing or decoding fails.
   init(data: Data, customDateFormatter: DateFormatter? = nil) throws {
     self = try Self.decode(data: data, customDateFormatter: customDateFormatter)
@@ -144,6 +145,7 @@ public extension FeedInitializable {
 extension FeedInitializable {
   /// Helper method for decoding data into a model.
   /// - Parameter data: The raw feed data.
+  /// - Parameter customDateFormatter: The optional `DateFormatter` that can be used to handle weird formats
   /// - Returns: A parsed feed model conforming to `FeedInitializable`.
   private static func decode(data: Data, customDateFormatter: DateFormatter? = nil) throws -> Self {
     let decoder: XMLDecoder = .init()


### PR DESCRIPTION
So this PR adds the optional DateFormatter parameter to `FeedInitializable` protocol initializers. 
The reason I'm doing this is because I stumbled on a set of feeds that used dates in really weird formats, not matching any standard. I know the feed is invalid then, but this works well for it. 