### PR TITLE
Reuse `RFC3339DateFormatter` when encoding/decoding a `JSONFeed`

### DIFF
--- a/Sources/FeedKit/FeedDateFormatter.swift
+++ b/Sources/FeedKit/FeedDateFormatter.swift
@@ -80,7 +80,7 @@ class PermissiveDateFormatter: DateFormatter, @unchecked Sendable {
 // MARK: - ISO8601 formatter
 
 /// Formatter for ISO8601 date specification.
-class ISO8601DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
+final class ISO8601DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
   /// List of date formats supported for ISO8601.
   override var dateFormats: [String] {
     [
@@ -103,7 +103,7 @@ class ISO8601DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
 // MARK: - RFC3339 formatter
 
 /// Formatter for RFC3339 date specification.
-class RFC3339DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
+final class RFC3339DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
   /// List of date formats supported for RFC3339.
   override var dateFormats: [String] {
     [
@@ -131,7 +131,7 @@ extension RFC3339DateFormatter {
 // MARK: - RFC822 formatter
 
 /// Formatter for RFC822 date specification with backup formats.
-class RFC822DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
+final class RFC822DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
   /// List of date formats supported for RFC822.
   override var dateFormats: [String] {
     [
@@ -190,7 +190,7 @@ class RFC822DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
 // MARK: - RFC1123 formatter
 
 /// Formatter for RFC1123 date specification.
-class RFC1123DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
+final class RFC1123DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
   /// List of date formats supported for RFC1123.
   override var dateFormats: [String] {
     [
@@ -226,7 +226,7 @@ enum DateSpec {
 // MARK: - FeedDateFormatter
 
 /// A formatter that handles multiple date specifications (ISO8601, RFC3339, RFC822).
-class FeedDateFormatter: DateFormatter, @unchecked Sendable {
+final class FeedDateFormatter: DateFormatter, @unchecked Sendable {
   // MARK: Lifecycle
 
   /// Initializes the date formatter with a specified date format.

--- a/Sources/FeedKit/FeedDateFormatter.swift
+++ b/Sources/FeedKit/FeedDateFormatter.swift
@@ -225,7 +225,7 @@ enum DateSpec {
 
 // MARK: - FeedDateFormatter
 
-/// A formatter that handles multiple date specifications (ISO8601, RFC3339, RFC822).
+/// A formatter that handles multiple date specifications (ISO8601, RFC3339, RFC822, RFC1123).
 final class FeedDateFormatter: DateFormatter, @unchecked Sendable {
   // MARK: Lifecycle
 

--- a/Sources/FeedKit/FeedDateFormatter.swift
+++ b/Sources/FeedKit/FeedDateFormatter.swift
@@ -124,6 +124,10 @@ class RFC3339DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
   }
 }
 
+extension RFC3339DateFormatter {
+    static let shared = RFC3339DateFormatter()
+}
+
 // MARK: - RFC822 formatter
 
 /// Formatter for RFC822 date specification with backup formats.
@@ -247,7 +251,7 @@ class FeedDateFormatter: DateFormatter, @unchecked Sendable {
   lazy var iso8601Formatter: ISO8601DateFormatter = .init()
 
   /// RFC3339 date formatter.
-  lazy var rfc3339Formatter: RFC3339DateFormatter = .init()
+  lazy var rfc3339Formatter: RFC3339DateFormatter = .shared
 
   /// RFC822 date formatter.
   lazy var rfc822Formatter: RFC822DateFormatter = .init()

--- a/Sources/FeedKit/Feeds/JSON/JSONFeed.swift
+++ b/Sources/FeedKit/Feeds/JSON/JSONFeed.swift
@@ -203,7 +203,7 @@ extension JSONFeed: Codable {
 
 extension JSONFeed: FeedInitializable {
   public init(data: Data) throws {
-    let formatter: RFC3339DateFormatter = .init()
+    let formatter: RFC3339DateFormatter = .shared
     let decoder: JSONDecoder = .init()
     decoder.dateDecodingStrategy = .formatted(formatter)
     self = try decoder.decode(JSONFeed.self, from: data)
@@ -213,7 +213,7 @@ extension JSONFeed: FeedInitializable {
 public extension JSONFeed {
   func toJSONString(formatted: Bool) throws -> String {
     let encoder: JSONEncoder = .init()
-    encoder.dateEncodingStrategy = .formatted(RFC3339DateFormatter())
+    encoder.dateEncodingStrategy = .formatted(RFC3339DateFormatter.shared)
     encoder.outputFormatting = formatted ? [.prettyPrinted] : []
     let data = try encoder.encode(self)
     guard let string = String(data: data, encoding: .utf8) else {


### PR DESCRIPTION
Three small changes relating to date formatters, each in a separate commit:
* Reuse `RFC3339DateFormatter` when encoding or decoding a `JSONFeed`
  * Totally open to suggestions on the formatting/style of this to fit the project
* Make date formatter classes final – seemed like an optimization to be made, given it's unlikely these will be subclassed
* Added a mention of RFC 1123 to the documentation comment of `FeedDateFormatter`, which currently supports multiple specs