### PR TITLE
FeedType: reduce the inspection prefix length & throw early for insufficient data

### DIFF
--- a/Sources/FeedKit/FeedType.swift
+++ b/Sources/FeedKit/FeedType.swift
@@ -84,7 +84,7 @@ public extension FeedType {
 }
 
 /// The number of bytes to inspect when determining the feed type.
-private let inspectionPrefixLength = 200
+private let inspectionPrefixLength = 128
 
 // MARK: - FeedInitializable
 
@@ -94,8 +94,12 @@ extension FeedType: FeedInitializable {
   /// - Parameter data: A `Data` object representing a feed to be inspected.
   /// - Returns: A `FeedType` if the data matches a known feed format, otherwise `nil`.
   public init(data: Data) throws {
-    // Inspect only the first 200 bytes. This helps improve performance while
-    // still providing enough data to reliably detect the feed format.
+    guard data.count >= inspectionPrefixLength else {
+      throw FeedError.unknownFeedFormat
+    }
+
+    // Inspect only the first `inspectionPrefixLength` bytes. This helps improve performance
+    // while still providing enough data to reliably detect the feed format.
     let string: String = .init(decoding: data.prefix(inspectionPrefixLength), as: UTF8.self)
 
     // Determine the feed type


### PR DESCRIPTION
Inspired by NetNewsWire (https://github.com/Ranchero-Software/NetNewsWire/blob/main/Modules/RSParser/Sources/Swift/Feeds/FeedType.swift), I've reduced the inspection prefix length that's used to determine the type of a feed, given some data and have also changed the initializer to throw early if there's insufficient data.

FeedKit unit tests still pass, and I've tested about 50 feeds in my RSS feed reader app and found no issues (a mix of popular news, tech and gaming feeds + smaller blogs).

Of course, if I've missed some reasoning for the current 200 value, feel free to ignore all this 😅 