### PR TITLE
Small optimisations to `FeedDateFormatter`

### DIFF
--- a/Sources/FeedKit/FeedDateFormatter.swift
+++ b/Sources/FeedKit/FeedDateFormatter.swift
@@ -260,21 +260,6 @@ final class FeedDateFormatter: DateFormatter, @unchecked Sendable {
 
   // MARK: Internal
 
-  /// The date specification to use for formatting dates.
-  let spec: DateSpec
-
-  /// ISO8601 date formatter.
-  lazy var iso8601Formatter: ISO8601DateFormatter = .init()
-
-  /// RFC3339 date formatter.
-  lazy var rfc3339Formatter: RFC3339DateFormatter = .init()
-
-  /// RFC822 date formatter.
-  lazy var rfc822Formatter: RFC822DateFormatter = .init()
-
-  /// RFC1123 date formatter.
-  lazy var rfc1123Formatter: RFC1123DateFormatter = .init()
-
   /// Converts a string to a Date based on the given date specification.
   ///
   /// - Parameters:
@@ -321,4 +306,21 @@ final class FeedDateFormatter: DateFormatter, @unchecked Sendable {
       fatalError()
     }
   }
+
+  // MARK: Private
+
+  /// The date specification to use for formatting dates.
+  private let spec: DateSpec
+
+  /// ISO8601 date formatter.
+  private lazy var iso8601Formatter: ISO8601DateFormatter = .init()
+
+  /// RFC3339 date formatter.
+  private lazy var rfc3339Formatter: RFC3339DateFormatter = .init()
+
+  /// RFC822 date formatter.
+  private lazy var rfc822Formatter: RFC822DateFormatter = .init()
+
+  /// RFC1123 date formatter.
+  private lazy var rfc1123Formatter: RFC1123DateFormatter = .init()
 }

--- a/Sources/FeedKit/FeedDateFormatter.swift
+++ b/Sources/FeedKit/FeedDateFormatter.swift
@@ -141,6 +141,8 @@ final class RFC3339DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
 
 /// Formatter for RFC822 date specification with backup formats.
 final class RFC822DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
+  // MARK: Internal
+
   /// List of date formats supported for RFC822.
   override var dateFormats: [String] {
     [
@@ -180,8 +182,7 @@ final class RFC822DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
     // handle these in full compliance with Unicode tr35-31. For example,
     // "Tues, 6 November 2007 12:00:00 GMT" is rejected because of the "Tues",
     // even though "Tues" is used as an example for EEE in tr35-31.
-    let trimRegEx = try! NSRegularExpression(pattern: "^[a-zA-Z]+, ([\\w :+-]+)$")
-    let trimmed = trimRegEx.stringByReplacingMatches(
+    let trimmed = Self.trimRegEx.stringByReplacingMatches(
       in: string,
       options: [],
       range: NSMakeRange(0, string.count),
@@ -196,6 +197,10 @@ final class RFC822DateFormatter: PermissiveDateFormatter, @unchecked Sendable {
     }
     return nil
   }
+
+  // MARK: Private
+
+  private static let trimRegEx = try! NSRegularExpression(pattern: "^[a-zA-Z]+, ([\\w :+-]+)$")
 }
 
 // MARK: - RFC1123 formatter


### PR DESCRIPTION
For `FeedDateFormatter`:
* Move the regular expression for trimming strings to a static property, so it's only initialised once and shared
* Make the date spec and formatters private