### PR TITLE
Implement lossy decoding for scalar values

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,7 @@ let package = Package(
         .process("Resources/xml/AtomDC.xml"),
         .process("Resources/xml/RSSAtom.xml"),
         .process("Resources/xml/Media.xml"),
+        .process("Resources/xml/LossyRSS.xml"),
         .process("Resources/xml/Syndication.xml"),
         .process("Resources/xml/iTunes.xml"),
         .process("Resources/xml/YouTube.xml"),

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ When you know the type of feed to be read, use a dedicated type.
 try await RSSFeed(urlString: "https://developer.apple.com/news/rss/news.rss")
 ```
 
+If you need to tolerate malformed optional scalar values from imperfect feeds, opt into lossy decoding:
+
+```swift
+try await RSSFeed(urlString: "https://developer.apple.com/news/rss/news.rss", lossy: true)
+```
+
 ### Universal
 
 When you don't know the type of feed, use the universal `Feed` enum type.
@@ -60,6 +66,12 @@ case let .atom(feed): // An AtomFeed instance
 case let .rss(feed): // An RSSFeed instance
 case let .json(feed): // A JSONFeed instance
 }
+```
+
+Lossy decoding is also available on the universal `Feed` type:
+
+```swift
+let feed = try await Feed(urlString: "https://surprise.me/feed", lossy: true)
 ```
 
 #### Manual Feed Type Detection
@@ -100,38 +112,40 @@ All feed types conform to `FeedInitializable`, sharing multiple common initializ
 From a URL `String`:
 
 ```swift
-init(urlString: String) async throws
+init(urlString: String, lossy: Bool = false) async throws
 ```
 
 From a `URL`, handling both local file URLs and remote URLs:
 
 ```swift
-init(url: URL) async throws
+init(url: URL, lossy: Bool = false) async throws
 ```
 
 From a local file `URL`:
 
 ```swift
-init(fileURL url: URL) throws
+init(fileURL url: URL, lossy: Bool = false) throws
 ```
 
 From a remote `URL`:
 
 ```swift
-init(remoteURL url: URL) async throws
+init(remoteURL url: URL, lossy: Bool = false) async throws
 ```
 
 From an XML or JSON `String`:
 
 ```swift
-init(string: String) throws
+init(string: String, lossy: Bool = false) throws
 ```
 
 From raw `Data`:
 
 ```swift
-init(data: Data) throws
+init(data: Data, lossy: Bool = false) throws
 ```
+
+When `lossy` is `true`, malformed optional scalar values such as invalid integers, doubles, booleans, or lengths are decoded as `nil` instead of causing the whole feed parse to fail.
 
 </details>
 

--- a/Sources/FeedKit/Extensions/KeyedDecodingContainer + LossyValues.swift
+++ b/Sources/FeedKit/Extensions/KeyedDecodingContainer + LossyValues.swift
@@ -1,0 +1,129 @@
+//
+// KeyedDecodingContainer + LossyValues.swift
+//
+// Copyright (c) 2016 - 2026 Nuno Dias
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+extension KeyedDecodingContainer {
+  func decodeLossyIfPresent(_ type: Int64.Type, forKey key: Key, lossy: Bool) throws -> Int64? {
+    if !lossy {
+      return try decodeIfPresent(Int64.self, forKey: key)
+    }
+
+    if let value = try? decodeIfPresent(Int64.self, forKey: key) {
+      return value
+    }
+
+    guard let value = try? decodeIfPresent(String.self, forKey: key)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !value.isEmpty
+    else {
+      return nil
+    }
+
+    return Int64(value)
+  }
+
+  func decodeLossyIfPresent(_ type: Int.Type, forKey key: Key, lossy: Bool) throws -> Int? {
+    if !lossy {
+      return try decodeIfPresent(Int.self, forKey: key)
+    }
+
+    if let value = try? decodeIfPresent(Int.self, forKey: key) {
+      return value
+    }
+
+    guard let value = try? decodeIfPresent(String.self, forKey: key)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !value.isEmpty
+    else {
+      return nil
+    }
+
+    return Int(value)
+  }
+
+  func decodeLossyIfPresent(_ type: Double.Type, forKey key: Key, lossy: Bool) throws -> Double? {
+    if !lossy {
+      return try decodeIfPresent(Double.self, forKey: key)
+    }
+
+    if let value = try? decodeIfPresent(Double.self, forKey: key) {
+      return value
+    }
+
+    guard let value = try? decodeIfPresent(String.self, forKey: key)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !value.isEmpty
+    else {
+      return nil
+    }
+
+    return Double(value)
+  }
+
+  func decodeLossyIfPresent(_ type: Bool.Type, forKey key: Key, lossy: Bool) throws -> Bool? {
+    if !lossy {
+      return try decodeIfPresent(Bool.self, forKey: key)
+    }
+
+    if let value = try? decodeIfPresent(Bool.self, forKey: key) {
+      return value
+    }
+
+    guard let value = try? decodeIfPresent(String.self, forKey: key)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+      !value.isEmpty
+    else {
+      return nil
+    }
+
+    return value.toBool()
+  }
+}
+
+enum FeedDecodingContext {
+  private static let key = "FeedKit.feedLossyDecoding"
+
+  static var isLossyDecodingEnabled: Bool {
+    Thread.current.threadDictionary[key] as? Bool ?? false
+  }
+
+  static func withLossyDecoding<T>(_ lossy: Bool, perform operation: () throws -> T) rethrows -> T {
+    let previousValue = Thread.current.threadDictionary[key]
+    Thread.current.threadDictionary[key] = lossy
+    defer {
+      if let previousValue {
+        Thread.current.threadDictionary[key] = previousValue
+      } else {
+        Thread.current.threadDictionary.removeObject(forKey: key)
+      }
+    }
+    return try operation()
+  }
+}
+
+extension Decoder {
+  var isFeedLossyDecodingEnabled: Bool {
+    FeedDecodingContext.isLossyDecodingEnabled
+  }
+}

--- a/Sources/FeedKit/Feed.swift
+++ b/Sources/FeedKit/Feed.swift
@@ -84,13 +84,14 @@ extension Feed: FeedInitializable {
   /// Initializes a `Feed` by parsing content from the specified URL string.
   ///
   /// - Parameter urlString: A valid URL string pointing to a feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: `FeedError.invalidURLString` if the URL string is invalid, or other
   ///           parsing errors if the feed content cannot be processed.
-  public init(urlString: String) async throws {
+  public init(urlString: String, lossy: Bool = false) async throws {
     guard let url = URL(string: urlString) else {
       throw FeedError.invalidURLString
     }
-    try await self.init(url: url)
+    try await self.init(url: url, lossy: lossy)
   }
 
   /// Initializes a `Feed` by parsing content from the specified URL.
@@ -98,30 +99,33 @@ extension Feed: FeedInitializable {
   /// This initializer automatically handles both local file URLs and remote URLs.
   ///
   /// - Parameter url: The URL pointing to the feed content.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: Various errors depending on whether the URL is local or remote.
-  public init(url: URL) async throws {
+  public init(url: URL, lossy: Bool = false) async throws {
     if url.isFileURL {
-      try self.init(fileURL: url)
+      try self.init(fileURL: url, lossy: lossy)
     } else {
-      try await self.init(remoteURL: url)
+      try await self.init(remoteURL: url, lossy: lossy)
     }
   }
 
   /// Initializes a `Feed` by parsing content from a local file URL.
   ///
   /// - Parameter url: A file URL pointing to the feed content.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: File reading errors or parsing errors if the content is invalid.
-  public init(fileURL url: URL) throws {
+  public init(fileURL url: URL, lossy: Bool = false) throws {
     let data = try Data(contentsOf: url)
-    try self.init(data: data)
+    try self.init(data: data, lossy: lossy)
   }
 
   /// Initializes a `Feed` by downloading and parsing content from a remote URL.
   ///
   /// - Parameter url: A remote URL pointing to the feed content.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: Network errors, HTTP errors, or parsing errors if the download
   ///           fails or the content is invalid.
-  public init(remoteURL url: URL) async throws {
+  public init(remoteURL url: URL, lossy: Bool = false) async throws {
     let session: URLSession = .shared
     let (data, response) = try await session.data(from: url)
 
@@ -134,19 +138,20 @@ extension Feed: FeedInitializable {
       throw FeedError.invalidHttpResponse(statusCode: statusCode)
     }
 
-    try self.init(data: data)
+    try self.init(data: data, lossy: lossy)
   }
 
   /// Initializes a `Feed` by parsing the provided string content.
   ///
   /// - Parameter string: A string containing the feed content.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: `FeedError` if the string cannot be converted to data or if
   ///           parsing fails.
-  public init(string: String) throws {
+  public init(string: String, lossy: Bool = false) throws {
     guard let data = string.data(using: .utf8) else {
       throw FeedError.invalidUtf8String
     }
-    try self.init(data: data)
+    try self.init(data: data, lossy: lossy)
   }
 
   /// Initializes a `Feed` by parsing the provided raw data.
@@ -156,22 +161,23 @@ extension Feed: FeedInitializable {
   /// into the appropriate format.
   ///
   /// - Parameter data: The raw feed data to parse.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: `FeedError.unknownFeedFormat` if the feed type cannot be determined or
   ///           if parsing fails.
-  public init(data: Data) throws {
+  public init(data: Data, lossy: Bool = false) throws {
     let feedType = try FeedType(data: data)
 
     switch feedType {
     case .atom:
-      let feed = try AtomFeed(data: data)
+      let feed = try AtomFeed(data: data, lossy: lossy)
       self = .atom(feed)
 
     case .rss:
-      let feed = try RSSFeed(data: data)
+      let feed = try RSSFeed(data: data, lossy: lossy)
       self = .rss(feed)
 
     case .json:
-      let feed = try JSONFeed(data: data)
+      let feed = try JSONFeed(data: data, lossy: lossy)
       self = .json(feed)
     }
   }

--- a/Sources/FeedKit/FeedInitializable.swift
+++ b/Sources/FeedKit/FeedInitializable.swift
@@ -31,70 +31,96 @@ import XMLKit
 public protocol FeedInitializable: Codable {
   /// Initializes from a URL string pointing to a feed.
   /// - Parameter urlString: The URL string of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the URL string is invalid or loading fails.
-  init(urlString: String) async throws
+  init(urlString: String, lossy: Bool) async throws
 
   /// Initializes from a URL pointing to a feed.
   /// - Parameter url: The URL of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the URL is invalid or loading fails.
-  init(url: URL) async throws
+  init(url: URL, lossy: Bool) async throws
 
   /// Initializes from a file URL.
   /// - Parameter url: The local file URL of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the file cannot be read or parsed.
-  init(fileURL url: URL) throws
+  init(fileURL url: URL, lossy: Bool) throws
   /// Initializes from a remote URL.
   /// - Parameter url: The remote URL of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if fetching or parsing fails.
-  init(remoteURL url: URL) async throws
+  init(remoteURL url: URL, lossy: Bool) async throws
 
   /// Initializes from a string.
   /// - Parameter string: The feed content as a string.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the string cannot be parsed.
-  init(string: String) throws
+  init(string: String, lossy: Bool) throws
 
   /// Initializes from data.
   /// - Parameter data: The feed content as raw data.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the data cannot be parsed.
-  init(data: Data) throws
+  init(data: Data, lossy: Bool) throws
 }
 
 // MARK: - Default
 
 public extension FeedInitializable {
+  init(urlString: String) async throws {
+    try await self.init(urlString: urlString, lossy: false)
+  }
+
   /// Default implementation for initializing from a URL string.
   /// - Parameter urlString: The URL string of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the feed cannot be loaded or parsed.
-  init(urlString: String) async throws {
+  init(urlString: String, lossy: Bool = false) async throws {
     guard let url = URL(string: urlString) else {
       throw FeedError.invalidURLString
     }
-    try await self.init(url: url)
+    try await self.init(url: url, lossy: lossy)
+  }
+
+  init(url: URL) async throws {
+    try await self.init(url: url, lossy: false)
   }
 
   /// Default implementation for initializing from a URL.
   /// - Parameter url: The URL of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the feed cannot be loaded or parsed.
-  init(url: URL) async throws {
+  init(url: URL, lossy: Bool = false) async throws {
     if url.isFileURL {
-      try self.init(fileURL: url)
+      try self.init(fileURL: url, lossy: lossy)
     } else {
-      try await self.init(remoteURL: url)
+      try await self.init(remoteURL: url, lossy: lossy)
     }
+  }
+
+  init(fileURL url: URL) throws {
+    try self.init(fileURL: url, lossy: false)
   }
 
   /// Initializes from a file URL.
   /// - Parameter url: The local file URL of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the file cannot be read or parsed.
-  init(fileURL url: URL) throws {
+  init(fileURL url: URL, lossy: Bool = false) throws {
     let data = try Data(contentsOf: url)
-    try self.init(data: data)
+    try self.init(data: data, lossy: lossy)
+  }
+
+  init(remoteURL url: URL) async throws {
+    try await self.init(remoteURL: url, lossy: false)
   }
 
   /// Initializes from a remote URL.
   /// - Parameter url: The remote URL of the feed.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if fetching or parsing fails.
-  init(remoteURL url: URL) async throws {
+  init(remoteURL url: URL, lossy: Bool = false) async throws {
     let session: URLSession = .shared
     let (data, response) = try await session.data(from: url)
 
@@ -107,24 +133,34 @@ public extension FeedInitializable {
       throw FeedError.invalidHttpResponse(statusCode: statusCode)
     }
 
-    try self.init(data: data)
+    try self.init(data: data, lossy: lossy)
+  }
+
+  init(string: String) throws {
+    try self.init(string: string, lossy: false)
   }
 
   /// Default implementation for initializing from a string.
   /// - Parameter string: The feed content as a string.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if the string cannot be converted to data or parsed.
-  init(string: String) throws {
+  init(string: String, lossy: Bool = false) throws {
     guard let data = string.data(using: .utf8) else {
       throw FeedError.invalidUtf8String
     }
-    try self.init(data: data)
+    try self.init(data: data, lossy: lossy)
+  }
+
+  init(data: Data) throws {
+    try self.init(data: data, lossy: false)
   }
 
   /// Default implementation for initializing from data.
   /// - Parameter data: The feed content as raw data.
+  /// - Parameter lossy: When `true`, malformed optional scalar values decode as `nil`.
   /// - Throws: An error if parsing or decoding fails.
-  init(data: Data) throws {
-    self = try Self.decode(data: data)
+  init(data: Data, lossy: Bool = false) throws {
+    self = try Self.decode(data: data, lossy: lossy)
   }
 }
 
@@ -134,10 +170,12 @@ extension FeedInitializable {
   /// Helper method for decoding data into a model.
   /// - Parameter data: The raw feed data.
   /// - Returns: A parsed feed model conforming to `FeedInitializable`.
-  private static func decode(data: Data) throws -> Self {
+  private static func decode(data: Data, lossy: Bool) throws -> Self {
     let decoder: XMLDecoder = .init()
     let formatter: FeedDateFormatter = .init(spec: .permissive)
     decoder.dateDecodingStrategy = .formatter(formatter)
-    return try decoder.decode(Self.self, from: data)
+    return try FeedDecodingContext.withLossyDecoding(lossy) {
+      try decoder.decode(Self.self, from: data)
+    }
   }
 }

--- a/Sources/FeedKit/Feeds/Atom/AtomFeedLink.swift
+++ b/Sources/FeedKit/Feeds/Atom/AtomFeedLink.swift
@@ -131,6 +131,38 @@ public struct AtomFeedLinkAttributes: Codable, Equatable, Hashable, Sendable {
   /// by the underlying protocol.  Link elements MAY have a length
   /// attribute.
   public var length: Int64?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    href = try container.decodeIfPresent(String.self, forKey: .href)
+    rel = try container.decodeIfPresent(String.self, forKey: .rel)
+    type = try container.decodeIfPresent(String.self, forKey: .type)
+    hreflang = try container.decodeIfPresent(String.self, forKey: .hreflang)
+    title = try container.decodeIfPresent(String.self, forKey: .title)
+    length = try container.decodeLossyIfPresent(Int64.self, forKey: .length, lossy: lossy)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(href, forKey: .href)
+    try container.encodeIfPresent(rel, forKey: .rel)
+    try container.encodeIfPresent(type, forKey: .type)
+    try container.encodeIfPresent(hreflang, forKey: .hreflang)
+    try container.encodeIfPresent(title, forKey: .title)
+    try container.encodeIfPresent(length, forKey: .length)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case href
+    case rel
+    case type
+    case hreflang
+    case title
+    case length
+  }
 }
 
 /// The "atom:link" element defines a reference from an entry or feed to

--- a/Sources/FeedKit/Feeds/JSON/JSONFeed.swift
+++ b/Sources/FeedKit/Feeds/JSON/JSONFeed.swift
@@ -185,6 +185,7 @@ extension JSONFeed: Codable {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
     version = try values.decode(String.self, forKey: .version)
     title = try values.decodeIfPresent(String.self, forKey: .title)
     userComment = try values.decodeIfPresent(String.self, forKey: .user_comment)
@@ -194,7 +195,7 @@ extension JSONFeed: Codable {
     nextURL = try values.decodeIfPresent(String.self, forKey: .next_url)
     icon = try values.decodeIfPresent(String.self, forKey: .icon)
     favicon = try values.decodeIfPresent(String.self, forKey: .favicon)
-    expired = try values.decodeIfPresent(Bool.self, forKey: .expired)
+    expired = try values.decodeLossyIfPresent(Bool.self, forKey: .expired, lossy: lossy)
     author = try values.decodeIfPresent(JSONFeedAuthor.self, forKey: .author)
     hubs = try values.decodeIfPresent([JSONFeedHub].self, forKey: .hubs)
     items = try values.decodeIfPresent([JSONFeedItem].self, forKey: .items)
@@ -202,11 +203,13 @@ extension JSONFeed: Codable {
 }
 
 extension JSONFeed: FeedInitializable {
-  public init(data: Data) throws {
+  public init(data: Data, lossy: Bool = false) throws {
     let formatter: RFC3339DateFormatter = .init()
     let decoder: JSONDecoder = .init()
     decoder.dateDecodingStrategy = .formatted(formatter)
-    self = try decoder.decode(JSONFeed.self, from: data)
+    self = try FeedDecodingContext.withLossyDecoding(lossy) {
+      try decoder.decode(JSONFeed.self, from: data)
+    }
   }
 }
 

--- a/Sources/FeedKit/Feeds/JSON/JSONFeedAttachment.swift
+++ b/Sources/FeedKit/Feeds/JSON/JSONFeedAttachment.swift
@@ -99,10 +99,11 @@ extension JSONFeedAttachment: Codable {
 
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
     title = try values.decodeIfPresent(String.self, forKey: .title)
     url = try values.decodeIfPresent(String.self, forKey: .url)
     mimeType = try values.decodeIfPresent(String.self, forKey: .mime_type)
-    sizeInBytes = try values.decodeIfPresent(Int.self, forKey: .size_in_bytes)
-    durationInSeconds = try values.decodeIfPresent(TimeInterval.self, forKey: .duration_in_seconds)
+    sizeInBytes = try values.decodeLossyIfPresent(Int.self, forKey: .size_in_bytes, lossy: lossy)
+    durationInSeconds = try values.decodeLossyIfPresent(Double.self, forKey: .duration_in_seconds, lossy: lossy)
   }
 }

--- a/Sources/FeedKit/Feeds/RSS/RSSFeedChannel.swift
+++ b/Sources/FeedKit/Feeds/RSS/RSSFeedChannel.swift
@@ -360,6 +360,7 @@ extension RSSFeedChannel: Codable {
 
   public init(from decoder: any Decoder) throws {
     let container: KeyedDecodingContainer<RSSFeedChannel.CodingKeys> = try decoder.container(keyedBy: RSSFeedChannel.CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
 
     title = try container.decodeIfPresent(String.self, forKey: CodingKeys.title)
     link = try container.decodeIfPresent(String.self, forKey: CodingKeys.link)
@@ -375,7 +376,7 @@ extension RSSFeedChannel: Codable {
     docs = try container.decodeIfPresent(String.self, forKey: CodingKeys.docs)
     cloud = try container.decodeIfPresent(RSSFeedCloud.self, forKey: CodingKeys.cloud)
     rating = try container.decodeIfPresent(String.self, forKey: CodingKeys.rating)
-    ttl = try container.decodeIfPresent(Int.self, forKey: CodingKeys.ttl)
+    ttl = try container.decodeLossyIfPresent(Int.self, forKey: CodingKeys.ttl, lossy: lossy)
     image = try container.decodeIfPresent(RSSFeedImage.self, forKey: CodingKeys.image)
     textInput = try container.decodeIfPresent(RSSFeedTextInput.self, forKey: CodingKeys.textInput)
     skipHours = try container.decodeIfPresent(RSSFeedSkipHours.self, forKey: CodingKeys.skipHours)

--- a/Sources/FeedKit/Feeds/RSS/RSSFeedCloud.swift
+++ b/Sources/FeedKit/Feeds/RSS/RSSFeedCloud.swift
@@ -61,6 +61,35 @@ public struct RSSFeedCloudAttributes: Codable, Equatable, Hashable, Sendable {
   /// is used instead and refers to the `protocol` attribute of the `cloud`
   /// element.
   public var `protocol`: String?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    domain = try container.decodeIfPresent(String.self, forKey: .domain)
+    port = try container.decodeLossyIfPresent(Int.self, forKey: .port, lossy: lossy)
+    path = try container.decodeIfPresent(String.self, forKey: .path)
+    registerProcedure = try container.decodeIfPresent(String.self, forKey: .registerProcedure)
+    `protocol` = try container.decodeIfPresent(String.self, forKey: .protocol)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(domain, forKey: .domain)
+    try container.encodeIfPresent(port, forKey: .port)
+    try container.encodeIfPresent(path, forKey: .path)
+    try container.encodeIfPresent(registerProcedure, forKey: .registerProcedure)
+    try container.encodeIfPresent(`protocol`, forKey: .protocol)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case domain
+    case port
+    case path
+    case registerProcedure
+    case `protocol`
+  }
 }
 
 // Allows processes to register with a cloud to be notified of updates to

--- a/Sources/FeedKit/Feeds/RSS/RSSFeedEnclosure.swift
+++ b/Sources/FeedKit/Feeds/RSS/RSSFeedEnclosure.swift
@@ -53,6 +53,29 @@ public struct RSSFeedEnclosureAttributes: Codable, Equatable, Hashable, Sendable
   ///
   /// Example: audio/mpeg
   public var type: String?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    url = try container.decodeIfPresent(String.self, forKey: .url)
+    length = try container.decodeLossyIfPresent(Int64.self, forKey: .length, lossy: lossy)
+    type = try container.decodeIfPresent(String.self, forKey: .type)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(url, forKey: .url)
+    try container.encodeIfPresent(length, forKey: .length)
+    try container.encodeIfPresent(type, forKey: .type)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case url
+    case length
+    case type
+  }
 }
 
 /// Describes a media object that is attached to the item.

--- a/Sources/FeedKit/Feeds/RSS/RSSFeedGUID.swift
+++ b/Sources/FeedKit/Feeds/RSS/RSSFeedGUID.swift
@@ -44,6 +44,20 @@ public struct RSSFeedGUIDAttributes: Codable, Equatable, Hashable, Sendable {
   /// the guid may not be assumed to be a url, or a url to anything in
   /// particular.
   public var isPermaLink: Bool?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    isPermaLink = try container.decodeLossyIfPresent(Bool.self, forKey: .isPermaLink, lossy: decoder.isFeedLossyDecodingEnabled)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(isPermaLink, forKey: .isPermaLink)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case isPermaLink
+  }
 }
 
 /// A string that uniquely identifies the item.

--- a/Sources/FeedKit/Feeds/RSS/RSSFeedImage.swift
+++ b/Sources/FeedKit/Feeds/RSS/RSSFeedImage.swift
@@ -117,12 +117,13 @@ extension RSSFeedImage: Codable {
 
   public init(from decoder: any Decoder) throws {
     let container: KeyedDecodingContainer<RSSFeedImage.CodingKeys> = try decoder.container(keyedBy: RSSFeedImage.CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
 
     url = try container.decodeIfPresent(String.self, forKey: RSSFeedImage.CodingKeys.url)
     title = try container.decodeIfPresent(String.self, forKey: RSSFeedImage.CodingKeys.title)
     link = try container.decodeIfPresent(String.self, forKey: RSSFeedImage.CodingKeys.link)
-    width = try container.decodeIfPresent(Int.self, forKey: RSSFeedImage.CodingKeys.width)
-    height = try container.decodeIfPresent(Int.self, forKey: RSSFeedImage.CodingKeys.height)
+    width = try container.decodeLossyIfPresent(Int.self, forKey: RSSFeedImage.CodingKeys.width, lossy: lossy)
+    height = try container.decodeLossyIfPresent(Int.self, forKey: RSSFeedImage.CodingKeys.height, lossy: lossy)
     description = try container.decodeIfPresent(String.self, forKey: RSSFeedImage.CodingKeys.description)
   }
 

--- a/Sources/FeedKit/Namespaces/Atom/AtomLink.swift
+++ b/Sources/FeedKit/Namespaces/Atom/AtomLink.swift
@@ -131,6 +131,38 @@ public struct AtomLinkAttributes: Codable, Equatable, Hashable, Sendable {
   /// by the underlying protocol.  Link elements MAY have a length
   /// attribute.
   public var length: Int64?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    href = try container.decodeIfPresent(String.self, forKey: .href)
+    rel = try container.decodeIfPresent(String.self, forKey: .rel)
+    type = try container.decodeIfPresent(String.self, forKey: .type)
+    hreflang = try container.decodeIfPresent(String.self, forKey: .hreflang)
+    title = try container.decodeIfPresent(String.self, forKey: .title)
+    length = try container.decodeLossyIfPresent(Int64.self, forKey: .length, lossy: lossy)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(href, forKey: .href)
+    try container.encodeIfPresent(rel, forKey: .rel)
+    try container.encodeIfPresent(type, forKey: .type)
+    try container.encodeIfPresent(hreflang, forKey: .hreflang)
+    try container.encodeIfPresent(title, forKey: .title)
+    try container.encodeIfPresent(length, forKey: .length)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case href
+    case rel
+    case type
+    case hreflang
+    case title
+    case length
+  }
 }
 
 /// The "atom:link" element defines a reference from an entry or feed to

--- a/Sources/FeedKit/Namespaces/Geo/GeoRSSSimple.swift
+++ b/Sources/FeedKit/Namespaces/Geo/GeoRSSSimple.swift
@@ -62,9 +62,10 @@ extension GeoRSSSimple: Codable {
 
   public init(from decoder: any Decoder) throws {
     let container: KeyedDecodingContainer<GeoRSSSimple.CodingKeys> = try decoder.container(keyedBy: GeoRSSSimple.CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
 
     point = try container.decodeIfPresent(GeoRSSSimplePoint.self, forKey: GeoRSSSimple.CodingKeys.point)
-    elevation = try container.decodeIfPresent(Double.self, forKey: GeoRSSSimple.CodingKeys.elevation)
+    elevation = try container.decodeLossyIfPresent(Double.self, forKey: GeoRSSSimple.CodingKeys.elevation, lossy: lossy)
   }
 
   public func encode(to encoder: any Encoder) throws {

--- a/Sources/FeedKit/Namespaces/Media/MediaContent.swift
+++ b/Sources/FeedKit/Namespaces/Media/MediaContent.swift
@@ -158,6 +158,62 @@ public struct MediaContent {
     /// XML 1.0 Specification (Third Edition). It is an optional
     /// attribute.
     public var lang: String?
+
+    public init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let lossy = decoder.isFeedLossyDecodingEnabled
+
+      url = try container.decodeIfPresent(String.self, forKey: .url)
+      fileSize = try container.decodeLossyIfPresent(Int.self, forKey: .fileSize, lossy: lossy)
+      type = try container.decodeIfPresent(String.self, forKey: .type)
+      medium = try container.decodeIfPresent(String.self, forKey: .medium)
+      isDefault = try container.decodeLossyIfPresent(Bool.self, forKey: .isDefault, lossy: lossy)
+      expression = try container.decodeIfPresent(String.self, forKey: .expression)
+      bitrate = try container.decodeLossyIfPresent(Int.self, forKey: .bitrate, lossy: lossy)
+      framerate = try container.decodeLossyIfPresent(Double.self, forKey: .framerate, lossy: lossy)
+      samplingrate = try container.decodeLossyIfPresent(Double.self, forKey: .samplingrate, lossy: lossy)
+      channels = try container.decodeLossyIfPresent(Int.self, forKey: .channels, lossy: lossy)
+      duration = try container.decodeLossyIfPresent(Int.self, forKey: .duration, lossy: lossy)
+      height = try container.decodeLossyIfPresent(Int.self, forKey: .height, lossy: lossy)
+      width = try container.decodeLossyIfPresent(Int.self, forKey: .width, lossy: lossy)
+      lang = try container.decodeIfPresent(String.self, forKey: .lang)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+
+      try container.encodeIfPresent(url, forKey: .url)
+      try container.encodeIfPresent(fileSize, forKey: .fileSize)
+      try container.encodeIfPresent(type, forKey: .type)
+      try container.encodeIfPresent(medium, forKey: .medium)
+      try container.encodeIfPresent(isDefault, forKey: .isDefault)
+      try container.encodeIfPresent(expression, forKey: .expression)
+      try container.encodeIfPresent(bitrate, forKey: .bitrate)
+      try container.encodeIfPresent(framerate, forKey: .framerate)
+      try container.encodeIfPresent(samplingrate, forKey: .samplingrate)
+      try container.encodeIfPresent(channels, forKey: .channels)
+      try container.encodeIfPresent(duration, forKey: .duration)
+      try container.encodeIfPresent(height, forKey: .height)
+      try container.encodeIfPresent(width, forKey: .width)
+      try container.encodeIfPresent(lang, forKey: .lang)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case url
+      case fileSize
+      case type
+      case medium
+      case isDefault
+      case expression
+      case bitrate
+      case framerate
+      case samplingrate
+      case channels
+      case duration
+      case height
+      case width
+      case lang
+    }
   }
 
   /// The element's attributes

--- a/Sources/FeedKit/Namespaces/Media/MediaEmbed.swift
+++ b/Sources/FeedKit/Namespaces/Media/MediaEmbed.swift
@@ -63,6 +63,29 @@ public struct MediaEmbed {
 
     /// The height size for the embeded Media.
     public var height: Int?
+
+    public init(from decoder: any Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      let lossy = decoder.isFeedLossyDecodingEnabled
+
+      url = try container.decodeIfPresent(String.self, forKey: .url)
+      width = try container.decodeLossyIfPresent(Int.self, forKey: .width, lossy: lossy)
+      height = try container.decodeLossyIfPresent(Int.self, forKey: .height, lossy: lossy)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+      var container = encoder.container(keyedBy: CodingKeys.self)
+
+      try container.encodeIfPresent(url, forKey: .url)
+      try container.encodeIfPresent(width, forKey: .width)
+      try container.encodeIfPresent(height, forKey: .height)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case url
+      case width
+      case height
+    }
   }
 
   /// The element's attributes.

--- a/Sources/FeedKit/Namespaces/Media/MediaPlayer.swift
+++ b/Sources/FeedKit/Namespaces/Media/MediaPlayer.swift
@@ -45,6 +45,29 @@ public struct MediaPlayerAttributes: Codable, Equatable, Hashable, Sendable {
   /// The height of the browser window that the URL should be opened in. It is an
   /// optional attribute.
   public var height: Int?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    url = try container.decodeIfPresent(String.self, forKey: .url)
+    width = try container.decodeLossyIfPresent(Int.self, forKey: .width, lossy: lossy)
+    height = try container.decodeLossyIfPresent(Int.self, forKey: .height, lossy: lossy)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(url, forKey: .url)
+    try container.encodeIfPresent(width, forKey: .width)
+    try container.encodeIfPresent(height, forKey: .height)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case url
+    case width
+    case height
+  }
 }
 
 /// Allows the media object to be accessed through a web browser media player

--- a/Sources/FeedKit/Namespaces/Media/MediaPrice.swift
+++ b/Sources/FeedKit/Namespaces/Media/MediaPrice.swift
@@ -54,6 +54,32 @@ public struct MediaPriceAttributes: Codable, Equatable, Hashable, Sendable {
 
   /// Use [ISO 4217] for currency codes. This is an optional attribute.
   public var currency: String?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    type = try container.decodeIfPresent(String.self, forKey: .type)
+    price = try container.decodeLossyIfPresent(Double.self, forKey: .price, lossy: lossy)
+    info = try container.decodeIfPresent(String.self, forKey: .info)
+    currency = try container.decodeIfPresent(String.self, forKey: .currency)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(type, forKey: .type)
+    try container.encodeIfPresent(price, forKey: .price)
+    try container.encodeIfPresent(info, forKey: .info)
+    try container.encodeIfPresent(currency, forKey: .currency)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case price
+    case info
+    case currency
+  }
 }
 
 /// Optional tag to include pricing information about a media object. If this

--- a/Sources/FeedKit/Namespaces/Media/MediaStarRating.swift
+++ b/Sources/FeedKit/Namespaces/Media/MediaStarRating.swift
@@ -52,6 +52,32 @@ public struct MediaStarRatingAttributes: Codable, Equatable, Hashable, Sendable 
 
   /// The star rating's maximum value.
   public var max: Int?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    average = try container.decodeLossyIfPresent(Double.self, forKey: .average, lossy: lossy)
+    count = try container.decodeLossyIfPresent(Int.self, forKey: .count, lossy: lossy)
+    min = try container.decodeLossyIfPresent(Int.self, forKey: .min, lossy: lossy)
+    max = try container.decodeLossyIfPresent(Int.self, forKey: .max, lossy: lossy)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(average, forKey: .average)
+    try container.encodeIfPresent(count, forKey: .count)
+    try container.encodeIfPresent(min, forKey: .min)
+    try container.encodeIfPresent(max, forKey: .max)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case average
+    case count
+    case min
+    case max
+  }
 }
 
 /// This element specifies the rating-related information about a media object.

--- a/Sources/FeedKit/Namespaces/Media/MediaStatistics.swift
+++ b/Sources/FeedKit/Namespaces/Media/MediaStatistics.swift
@@ -42,6 +42,26 @@ public struct MediaStatisticsAttributes: Codable, Equatable, Hashable, Sendable 
 
   /// The number fo favorites.
   public var favorites: Int?
+
+  public init(from decoder: any Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
+
+    views = try container.decodeLossyIfPresent(Int.self, forKey: .views, lossy: lossy)
+    favorites = try container.decodeLossyIfPresent(Int.self, forKey: .favorites, lossy: lossy)
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+
+    try container.encodeIfPresent(views, forKey: .views)
+    try container.encodeIfPresent(favorites, forKey: .favorites)
+  }
+
+  private enum CodingKeys: String, CodingKey {
+    case views
+    case favorites
+  }
 }
 
 /// This element specifies various statistics about a media object like the

--- a/Sources/FeedKit/Namespaces/Syndication/Syndication.swift
+++ b/Sources/FeedKit/Namespaces/Syndication/Syndication.swift
@@ -92,9 +92,10 @@ extension Syndication: Codable {
 
   public init(from decoder: any Decoder) throws {
     let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
 
     updatePeriod = try container.decodeIfPresent(SyndicationUpdatePeriod.self, forKey: CodingKeys.updatePeriod)
-    updateFrequency = try container.decodeIfPresent(Int.self, forKey: CodingKeys.updateFrequency)
+    updateFrequency = try container.decodeLossyIfPresent(Int.self, forKey: CodingKeys.updateFrequency, lossy: lossy)
     updateBase = try container.decodeIfPresent(Date.self, forKey: CodingKeys.updateBase)
   }
 

--- a/Sources/FeedKit/Namespaces/iTunes/ITunes.swift
+++ b/Sources/FeedKit/Namespaces/iTunes/ITunes.swift
@@ -330,6 +330,7 @@ extension ITunes: Codable {
 
   public init(from decoder: any Decoder) throws {
     let container: KeyedDecodingContainer<CodingKeys> = try decoder.container(keyedBy: CodingKeys.self)
+    let lossy = decoder.isFeedLossyDecodingEnabled
 
     author = try container.decodeIfPresent(String.self, forKey: CodingKeys.author)
     block = try container.decodeIfPresent(String.self, forKey: CodingKeys.block)
@@ -338,7 +339,7 @@ extension ITunes: Codable {
     duration = try container.decodeIfPresent(String.self, forKey: CodingKeys.duration)?.toDuration()
     explicit = try container.decodeIfPresent(String.self, forKey: CodingKeys.explicit)
     isClosedCaptioned = try container.decodeIfPresent(String.self, forKey: CodingKeys.isClosedCaptioned)
-    order = try container.decodeIfPresent(Int.self, forKey: CodingKeys.order)
+    order = try container.decodeLossyIfPresent(Int.self, forKey: CodingKeys.order, lossy: lossy)
     complete = try container.decodeIfPresent(String.self, forKey: CodingKeys.complete)
     newFeedURL = try container.decodeIfPresent(String.self, forKey: CodingKeys.newFeedURL)
     owner = try container.decodeIfPresent(iTunesOwner.self, forKey: CodingKeys.owner)
@@ -348,7 +349,7 @@ extension ITunes: Codable {
     keywords = try container.decodeIfPresent(String.self, forKey: CodingKeys.keywords)
     type = try container.decodeIfPresent(String.self, forKey: CodingKeys.type)
     episodeType = try container.decodeIfPresent(String.self, forKey: CodingKeys.episodeType)
-    season = try container.decodeIfPresent(Int.self, forKey: CodingKeys.season)
+    season = try container.decodeLossyIfPresent(Int.self, forKey: CodingKeys.season, lossy: lossy)
     episode = try container.decodeIfPresent(String.self, forKey: CodingKeys.episode)
   }
 

--- a/Tests/FeedKitTests/Resources/xml/LossyRSS.xml
+++ b/Tests/FeedKitTests/Resources/xml/LossyRSS.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>Lossy RSS</title>
+    <link>https://example.com/</link>
+    <description>Feed with malformed optional numeric values.</description>
+    <image>
+      <url>https://example.com/logo.png</url>
+      <title>Lossy RSS</title>
+      <link>https://example.com/</link>
+      <width>88px</width>
+      <height>31px</height>
+    </image>
+    <item>
+      <title>Episode 1</title>
+      <link>https://example.com/episodes/1</link>
+      <description>First episode.</description>
+      <enclosure
+        url="https://example.com/audio/episode-1.mp3"
+        length="12216320 bytes"
+        type="audio/mpeg"
+      />
+      <media:content
+        url="https://example.com/video/episode-1.mp4"
+        height="720px"
+        width="1280"
+        duration="3600 seconds"
+      />
+    </item>
+  </channel>
+</rss>

--- a/Tests/FeedKitTests/Tests/FeedTests.swift
+++ b/Tests/FeedKitTests/Tests/FeedTests.swift
@@ -78,4 +78,17 @@ struct FeedTests: FeedKitTestable {
     // Then
     #expect(expected == actual)
   }
+
+  @Test
+  func lossyData() throws {
+    // Given
+    let data = data(resource: "LossyRSS", withExtension: "xml")
+
+    // When
+    let actual = try Feed(data: data, lossy: true)
+
+    // Then
+    #expect(actual.rss?.channel?.items?.first?.enclosure?.attributes?.length == nil)
+    #expect(actual.rss?.channel?.items?.first?.media?.contents?.first?.attributes?.height == nil)
+  }
 }

--- a/Tests/FeedKitTests/Tests/RSSTests.swift
+++ b/Tests/FeedKitTests/Tests/RSSTests.swift
@@ -38,4 +38,31 @@ struct RSSTests: FeedKitTestable {
     // Then
     #expect(expected == actual)
   }
+
+  @Test
+  func lossyDecodingDisabledByDefault() throws {
+    // Given
+    let data = data(resource: "LossyRSS", withExtension: "xml")
+
+    // When / Then
+    #expect(throws: DecodingError.self) {
+      try RSSFeed(data: data)
+    }
+  }
+
+  @Test
+  func lossyDecodingAllowsMalformedOptionalNumbers() throws {
+    // Given
+    let data = data(resource: "LossyRSS", withExtension: "xml")
+
+    // When
+    let actual = try RSSFeed(data: data, lossy: true)
+
+    // Then
+    #expect(actual.channel?.image?.width == nil)
+    #expect(actual.channel?.image?.height == nil)
+    #expect(actual.channel?.items?.first?.enclosure?.attributes?.length == nil)
+    #expect(actual.channel?.items?.first?.media?.contents?.first?.attributes?.height == nil)
+    #expect(actual.channel?.items?.first?.media?.contents?.first?.attributes?.width == 1280)
+  }
 }


### PR DESCRIPTION
Adds a `lossy` parameter, default false, to `Feed` and typed initializers. When true, if there's an error decoding a value nil is filled in instead of the whole parse operation erroring out.

Related to #173. This solution is not particularly graceful, but it does the trick when you just need basic info and can tolerate missing fields due to malformed values.