### PR TITLE
Attribute escaping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: xcrun simctl list devices available
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=macOS,arch=arm64' test | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=macOS,arch=arm64' -skipMacroValidation test | xcbeautify
 
   macos-build-and-test-xcodebuild-ios:
     name: Test (xcodebuild iOS)
@@ -73,7 +73,7 @@ jobs:
         run: xcrun simctl list devices available
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=iOS Simulator,name=iPhone 17' test | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=iOS Simulator,name=iPhone 17' -skipMacroValidation test | xcbeautify
 
   macos-build-and-test-xcodebuild-tvos:
     name: Test (xcodebuild tvOS)
@@ -89,7 +89,7 @@ jobs:
         run: xcrun simctl list devices available
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=tvOS Simulator,name=Apple TV' test | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=tvOS Simulator,name=Apple TV' -skipMacroValidation test | xcbeautify
 
   macos-build-and-test-xcodebuild-watchos:
     name: Test (xcodebuild watchOS)
@@ -105,7 +105,7 @@ jobs:
         run: xcrun simctl list devices available
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)' test | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)' -skipMacroValidation test | xcbeautify
 
   macos-build-and-test-xcodebuild-visionos:
     name: Test (xcodebuild visionOS)
@@ -121,4 +121,4 @@ jobs:
         run: xcrun simctl list devices available
 
       - name: Build and Test
-        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=26.2' test | xcbeautify
+        run: set -o pipefail && xcodebuild -scheme FeedKit-Package -destination 'platform=visionOS Simulator,name=Apple Vision Pro,OS=26.2' -skipMacroValidation test | xcbeautify

--- a/Package.swift
+++ b/Package.swift
@@ -26,13 +26,19 @@ let package = Package(
       ]
     )
   ],
+  dependencies: [
+    .package(url: "https://github.com/swiftlang/swift-testing.git", from: "0.9.0")
+  ],
   targets: [
     .target(
       name: "XMLKit"
     ),
     .testTarget(
       name: "XMLKitTests",
-      dependencies: ["XMLKit"],
+      dependencies: [
+        "XMLKit",
+        .product(name: "Testing", package: "swift-testing")
+      ],
       resources: [
         .process("Resources/xml/Sample.xml")
       ]
@@ -46,7 +52,8 @@ let package = Package(
     .testTarget(
       name: "FeedKitTests",
       dependencies: [
-        "FeedKit"
+        "FeedKit",
+        .product(name: "Testing", package: "swift-testing")
       ],
       resources: [
         .process("Resources/json/feed.json"),

--- a/Sources/XMLKit/XMLNode.swift
+++ b/Sources/XMLKit/XMLNode.swift
@@ -234,6 +234,7 @@ extension XMLNode: XMLStringConvertible {
       xml += "\(formatted ? indent : "")</\(name)>\(formatted ? "\n" : "")"
     } else if let text {
       // Element has text, close opening tag and add text
+      let text = isXhtml ? text : text.escapeCharacters()
       xml += ">\(text)</\(name)>\(formatted ? "\n" : "")"
 
     } else {
@@ -257,7 +258,7 @@ extension XMLNode {
     if let attributesNode = children?.first(where: { $0.name == "@attributes" }) {
       // Append each attribute in the format: name="value".
       for attribute in attributesNode.children ?? [] {
-        result += " \(attribute.name)=\"\(attribute.text ?? "")\""
+        result += " \(attribute.name)=\"\((attribute.text ?? "").escapeCharacters())\""
       }
     }
     return result

--- a/Tests/FeedKitTests/Tests/RSSFeedEncodingTests.swift
+++ b/Tests/FeedKitTests/Tests/RSSFeedEncodingTests.swift
@@ -1,0 +1,78 @@
+//
+// RSSFeedEncodingTests.swift
+//
+// Copyright (c) 2016 - 2026 Nuno Dias
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+@testable import FeedKit
+import Testing
+
+@Suite("RSS Encoding")
+struct RSSFeedEncodingTests: FeedKitTestable {
+  @Test("Ampersands in a media:content url attribute are escaped as &amp;")
+  func escapesAmpersandInMediaContentURL() throws {
+    // Given
+    let feed = RSSFeed(
+      channel: .init(
+        title: "Test Channel",
+        items: [
+          .init(
+            title: "Test Item",
+            media: .init(
+              contents: [
+                .init(attributes: .init(url: "http://example.com/video?a=1&b=2"))
+              ]
+            )
+          )
+        ]
+      )
+    )
+
+    // When
+    let xml = try feed.toXMLString(formatted: true)
+
+    // Then
+    #expect(xml.contains(#"url="http://example.com/video?a=1&amp;b=2""#))
+    #expect(!xml.contains(#"url="http://example.com/video?a=1&b=2""#))
+  }
+
+  @Test("Ampersands in element text (e.g. link) are escaped as &amp;")
+  func escapesAmpersandInElementText() throws {
+    // Given
+    let feed = RSSFeed(
+      channel: .init(
+        title: "Test Channel",
+        items: [
+          .init(
+            title: "Test Item",
+            link: "http://example.com/article?a=1&b=2"
+          )
+        ]
+      )
+    )
+
+    // When
+    let xml = try feed.toXMLString(formatted: true)
+
+    // Then
+    #expect(xml.contains("<link>http://example.com/article?a=1&amp;b=2</link>"))
+    #expect(!xml.contains("<link>http://example.com/article?a=1&b=2</link>"))
+  }
+}


### PR DESCRIPTION
Was using FeedKit in my FeedProxy. When serializing Feed with it's own method it did work due to invalid media:content url. &amp; became & which isnt correct XML. And it is general attribute values